### PR TITLE
Fix rest site and event option index handling

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -234,16 +234,17 @@ public static partial class McpMod
 
         int index = indexElem.GetInt32();
 
-        var buttons = FindAll<NEventOptionButton>(uiRoom)
-            .Where(b => !b.Option.IsLocked)
-            .ToList();
+        var buttons = FindAll<NEventOptionButton>(uiRoom);
 
         if (buttons.Count == 0)
-            return Error("No unlocked event options available");
+            return Error("No event options available");
         if (index < 0 || index >= buttons.Count)
-            return Error($"Event option index {index} out of range ({buttons.Count} unlocked options)");
+            return Error($"Event option index {index} out of range ({buttons.Count} options)");
 
         var button = buttons[index];
+        if (button.Option.IsLocked)
+            return Error($"Event option index {index} is locked");
+
         string title = SafeGetText(() => button.Option.Title) ?? "option";
         button.ForceClick();
 
@@ -288,14 +289,15 @@ public static partial class McpMod
         if (restRoom == null)
             return Error("Rest site room is not open");
 
-        var buttons = FindAll<NRestSiteButton>(restRoom)
-            .Where(b => b.Option.IsEnabled)
-            .ToList();
+        var buttons = FindAll<NRestSiteButton>(restRoom);
 
         if (index < 0 || index >= buttons.Count)
-            return Error($"Rest option index {index} out of range ({buttons.Count} enabled options)");
+            return Error($"Rest option index {index} out of range ({buttons.Count} options)");
 
         var button = buttons[index];
+        if (!button.Option.IsEnabled)
+            return Error($"Rest option index {index} is disabled");
+
         string optionName = SafeGetText(() => button.Option.Title) ?? button.Option.OptionId;
         button.ForceClick();
 

--- a/docs/raw_api.md
+++ b/docs/raw_api.md
@@ -189,7 +189,7 @@ Returns the current game state. The `state_type` field indicates the screen:
 ```json
 { "action": "choose_event_option", "index": 0 }
 ```
-- `index`: 0-based index of the unlocked option (from GET response)
+- `index`: 0-based index of the option from the current GET response
 - Works for both regular events and ancients (after dialogue)
 
 **Advance ancient dialogue:**

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -294,7 +294,7 @@ async def event_choose_option(option_index: int) -> str:
     Also used to click the Proceed option after an event resolves.
 
     Args:
-        option_index: 0-based index of the unlocked option.
+        option_index: 0-based index of the option from the current event state.
     """
     try:
         return await _post({"action": "choose_event_option", "index": option_index})
@@ -524,7 +524,7 @@ async def mp_event_choose_option(option_index: int) -> str:
     For individual events: immediate choice, same as singleplayer.
 
     Args:
-        option_index: 0-based index of the unlocked option.
+        option_index: 0-based index of the option from the current event state.
     """
     try:
         return await _mp_post({"action": "choose_event_option", "index": option_index})


### PR DESCRIPTION
Disabled event options can lead to index drift. This patch should effectively fix this issue.

## Summary
- align event option action indices with the indices exposed in MCP state
- align rest site option action indices with the indices exposed in MCP state
- update MCP docs to match the corrected index contract