### PR TITLE
Add discard_potion action for singleplayer and multiplayer

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -49,6 +49,7 @@ public static partial class McpMod
         {
             "play_card" => ExecutePlayCard(player, data),
             "use_potion" => ExecuteUsePotion(player, data),
+            "discard_potion" => ExecuteDiscardPotion(player, data),
             "end_turn" => ExecuteEndTurn(player),
             "choose_map_node" => ExecuteChooseMapNode(data),
             "choose_event_option" => ExecuteChooseEventOption(data),
@@ -227,6 +228,29 @@ public static partial class McpMod
         {
             ["status"] = "ok",
             ["message"] = $"Using potion '{SafeGetText(() => potion.Title)}' from slot {slot}{targetMsg}"
+        };
+    }
+
+    private static Dictionary<string, object?> ExecuteDiscardPotion(Player player, Dictionary<string, JsonElement> data)
+    {
+        if (!data.TryGetValue("slot", out var slotElem))
+            return Error("Missing 'slot' (potion slot index)");
+
+        int slot = slotElem.GetInt32();
+        if (slot < 0 || slot >= player.PotionSlots.Count)
+            return Error($"Potion slot {slot} out of range (player has {player.PotionSlots.Count} slots)");
+
+        var potion = player.GetPotionAtSlotIndex(slot);
+        if (potion == null)
+            return Error($"No potion in slot {slot}");
+
+        string potionName = SafeGetText(() => potion.Title) ?? "unknown";
+        _ = PotionCmd.Discard(potion);
+
+        return new Dictionary<string, object?>
+        {
+            ["status"] = "ok",
+            ["message"] = $"Discarded potion '{potionName}' from slot {slot}"
         };
     }
 

--- a/McpMod.MultiplayerActions.cs
+++ b/McpMod.MultiplayerActions.cs
@@ -31,6 +31,7 @@ public static partial class McpMod
             // Delegated to existing sync-safe handlers
             "play_card" => ExecutePlayCard(player, data),
             "use_potion" => ExecuteUsePotion(player, data),
+            "discard_potion" => ExecuteDiscardPotion(player, data),
             "choose_map_node" => ExecuteChooseMapNode(data),
             "choose_event_option" => ExecuteChooseEventOption(data),
             "advance_dialogue" => ExecuteAdvanceDialogue(),

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -102,6 +102,22 @@ async def use_potion(slot: int, target: str | None = None) -> str:
 
 
 @mcp.tool()
+async def discard_potion(slot: int) -> str:
+    """Discard a potion from the player's potion slots to free up space.
+
+    Use this when all potion slots are full and you need room for incoming potions
+    (e.g. before collecting a potion reward).
+
+    Args:
+        slot: Potion slot index to discard (as shown in game state).
+    """
+    try:
+        return await _post({"action": "discard_potion", "slot": slot})
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
 async def proceed_to_map() -> str:
     """Proceed from the current screen to the map.
 
@@ -574,6 +590,19 @@ async def mp_use_potion(slot: int, target: str | None = None) -> str:
         body["target"] = target
     try:
         return await _mp_post(body)
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def mp_discard_potion(slot: int) -> str:
+    """[Multiplayer] Discard a potion from the local player's potion slots to free up space.
+
+    Args:
+        slot: Potion slot index to discard (as shown in game state).
+    """
+    try:
+        return await _mp_post({"action": "discard_potion", "slot": slot})
     except Exception as e:
         return _handle_error(e)
 


### PR DESCRIPTION
- Adds `discard_potion` action (C# + Python MCP tool) for both singleplayer and multiplayer

Closes #31