### PR TITLE
Allow configurable port via STS2_MCP.conf

### DIFF
--- a/McpMod.cs
+++ b/McpMod.cs
@@ -20,6 +20,8 @@ namespace STS2_MCP;
 public static partial class McpMod
 {
     public const string Version = "0.3.2";
+    public const int DefaultPort = 15526;
+    private const string ConfigFileName = "STS2_MCP.conf";
 
     private static HttpListener? _listener;
     private static Thread? _serverThread;
@@ -32,6 +34,44 @@ public static partial class McpMod
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
     };
 
+    private static int LoadPort()
+    {
+        try
+        {
+            string? modDir = Path.GetDirectoryName(
+                System.Reflection.Assembly.GetExecutingAssembly().Location);
+            if (modDir == null) return DefaultPort;
+
+            string configPath = Path.Combine(modDir, ConfigFileName);
+            if (!File.Exists(configPath))
+            {
+                // Create default config so the user knows it's configurable
+                var defaultConfig = new Dictionary<string, object> { ["port"] = DefaultPort };
+                string json = JsonSerializer.Serialize(defaultConfig, _jsonOptions);
+                File.WriteAllText(configPath, json);
+                GD.Print($"[STS2 MCP] Created default config at {configPath}");
+                return DefaultPort;
+            }
+
+            string content = File.ReadAllText(configPath);
+            using var doc = JsonDocument.Parse(content);
+            if (doc.RootElement.TryGetProperty("port", out var portElem)
+                && portElem.TryGetInt32(out int port)
+                && port is > 0 and <= 65535)
+            {
+                return port;
+            }
+
+            GD.PrintErr($"[STS2 MCP] Invalid or missing 'port' in {configPath}, using default {DefaultPort}");
+            return DefaultPort;
+        }
+        catch (Exception ex)
+        {
+            GD.PrintErr($"[STS2 MCP] Failed to load config: {ex.Message}, using default port {DefaultPort}");
+            return DefaultPort;
+        }
+    }
+
     public static void Initialize()
     {
         try
@@ -43,9 +83,11 @@ public static partial class McpMod
             var tree = (SceneTree)Engine.GetMainLoop();
             tree.Connect(SceneTree.SignalName.ProcessFrame, Callable.From(ProcessMainThreadQueue));
 
+            int port = LoadPort();
+
             _listener = new HttpListener();
-            _listener.Prefixes.Add("http://localhost:15526/");
-            _listener.Prefixes.Add("http://127.0.0.1:15526/");
+            _listener.Prefixes.Add($"http://localhost:{port}/");
+            _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
             _listener.Start();
 
             _serverThread = new Thread(ServerLoop)
@@ -55,7 +97,7 @@ public static partial class McpMod
             };
             _serverThread.Start();
 
-            GD.Print($"[STS2 MCP] v{Version} server started on http://localhost:15526/");
+            GD.Print($"[STS2 MCP] v{Version} server started on http://localhost:{port}/");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Allows custom port by editing `<game_dir>/mods/STS2_MCP.conf` (a json file).