### PR TITLE
Add fake merchant event support

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -12,8 +12,11 @@ using MegaCrit.Sts2.Core.Nodes.Relics;
 using MegaCrit.Sts2.Core.Nodes.Screens.Overlays;
 using MegaCrit.Sts2.Core.Nodes.Screens.TreasureRoomRelic;
 using MegaCrit.Sts2.Core.Entities.Merchant;
+using MegaCrit.Sts2.Core.Models.Events;
 using MegaCrit.Sts2.Core.Nodes.Events;
+using MegaCrit.Sts2.Core.Nodes.Events.Custom;
 using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
+using MegaCrit.Sts2.Core.Nodes.Screens.Shops;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Map;
 using MegaCrit.Sts2.Core.Rooms;
@@ -339,15 +342,47 @@ public static partial class McpMod
 
     private static Dictionary<string, object?> ExecuteShopPurchase(Player player, Dictionary<string, JsonElement> data)
     {
-        if (player.RunState.CurrentRoom is not MerchantRoom merchantRoom)
+        MerchantInventory? inventory = null;
+
+        if (player.RunState.CurrentRoom is MerchantRoom merchantRoom)
+        {
+            // Regular merchant — auto-open inventory if needed
+            var merchUI = NMerchantRoom.Instance;
+            if (merchUI?.Inventory != null && !merchUI.Inventory.IsOpen)
+                merchUI.OpenInventory();
+            inventory = merchantRoom.Inventory;
+        }
+        else if (player.RunState.CurrentRoom is EventRoom eventRoom
+                 && eventRoom.CanonicalEvent is FakeMerchant
+                 && (eventRoom.LocalMutableEvent ?? eventRoom.CanonicalEvent) is FakeMerchant fakeMerchant)
+        {
+            // Fake merchant event — auto-open via button if needed
+            if (!fakeMerchant.StartedFight)
+            {
+                var uiRoom = NEventRoom.Instance;
+                if (uiRoom != null)
+                {
+                    var fmNode = FindFirst<NFakeMerchant>(uiRoom);
+                    if (fmNode != null)
+                    {
+                        var inventoryUI = FindFirst<NMerchantInventory>(fmNode);
+                        if (inventoryUI != null && !inventoryUI.IsOpen)
+                        {
+                            var btn = fmNode.MerchantButton;
+                            if (btn != null && btn.Visible && btn.IsEnabled)
+                                btn.ForceClick();
+                        }
+                    }
+                }
+            }
+            inventory = fakeMerchant.Inventory;
+        }
+        else
+        {
             return Error("Not in a shop");
+        }
 
-        // Auto-open inventory if needed (guard null — OpenInventory() dereferences Inventory.IsOpen)
-        var merchUI = NMerchantRoom.Instance;
-        if (merchUI?.Inventory != null && !merchUI.Inventory.IsOpen)
-            merchUI.OpenInventory();
-
-        if (merchantRoom.Inventory == null)
+        if (inventory == null)
             return Error("Shop inventory not ready yet; wait a moment and retry");
 
         if (!data.TryGetValue("index", out var indexElem))
@@ -355,7 +390,7 @@ public static partial class McpMod
 
         int index = indexElem.GetInt32();
 
-        var allEntries = merchantRoom.Inventory.AllEntries.ToList();
+        var allEntries = inventory.AllEntries.ToList();
         if (index < 0 || index >= allEntries.Count)
             return Error($"Shop item index {index} out of range ({allEntries.Count} items)");
 
@@ -366,7 +401,7 @@ public static partial class McpMod
             return Error($"Not enough gold (need {entry.Cost}, have {player.Gold})");
 
         // Fire-and-forget purchase (same path as AutoSlay)
-        _ = entry.OnTryPurchaseWrapper(merchantRoom.Inventory);
+        _ = entry.OnTryPurchaseWrapper(inventory);
 
         return new Dictionary<string, object?>
         {
@@ -523,6 +558,28 @@ public static partial class McpMod
             {
                 merchRoom.ProceedButton.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Proceeding from shop" };
+            }
+        }
+
+        // Try fake merchant — close inventory first if open, then proceed
+        if (NEventRoom.Instance is { } evtRoom)
+        {
+            var fmNode = FindFirst<NFakeMerchant>(evtRoom);
+            if (fmNode != null)
+            {
+                var fmInventory = FindFirst<NMerchantInventory>(fmNode);
+                if (fmInventory is { IsOpen: true })
+                {
+                    var backBtn = FindFirst<NBackButton>(fmNode);
+                    if (backBtn is { IsEnabled: true })
+                        backBtn.ForceClick();
+                }
+                var proceedBtn = FindFirst<NProceedButton>(fmNode);
+                if (proceedBtn is { IsEnabled: true })
+                {
+                    proceedBtn.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Proceeding from fake merchant" };
+                }
             }
         }
 

--- a/McpMod.Formatting.cs
+++ b/McpMod.Formatting.cs
@@ -91,6 +91,11 @@ public static partial class McpMod
             FormatShopMarkdown(sb, shopData);
         }
 
+        if (state.TryGetValue("fake_merchant", out var fmObj) && fmObj is Dictionary<string, object?> fmData)
+        {
+            FormatFakeMerchantMarkdown(sb, fmData);
+        }
+
         if (state.TryGetValue("map", out var mapObj) && mapObj is Dictionary<string, object?> mapData)
         {
             FormatMapMarkdown(sb, mapData);
@@ -376,6 +381,29 @@ public static partial class McpMod
         bool canProceed = shop.TryGetValue("can_proceed", out var cp) && cp is true;
         sb.AppendLine($"**Can proceed:** {(canProceed ? "Yes" : "No")}");
         sb.AppendLine();
+    }
+
+    private static void FormatFakeMerchantMarkdown(StringBuilder sb, Dictionary<string, object?> fm)
+    {
+        string name = fm.TryGetValue("event_name", out var n) && n != null ? n.ToString()! : "Fake Merchant";
+        bool startedFight = fm.TryGetValue("started_fight", out var sf) && sf is true;
+
+        sb.AppendLine($"## Event: {name}");
+        sb.AppendLine();
+
+        if (startedFight)
+        {
+            sb.AppendLine("*The fake merchant has been defeated. Use `proceed` to open the map.*");
+            sb.AppendLine();
+            return;
+        }
+
+        sb.AppendLine("*This is a fake merchant selling dubious relics. You can browse and buy, or throw a Foul Potion (use_potion) to start a fight.*");
+        sb.AppendLine();
+
+        // Reuse shop formatting for the nested shop object
+        if (fm.TryGetValue("shop", out var shopObj) && shopObj is Dictionary<string, object?> shopData)
+            FormatShopMarkdown(sb, shopData);
     }
 
     private static void FormatMapMarkdown(StringBuilder sb, Dictionary<string, object?> map)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -14,7 +14,9 @@ using MegaCrit.Sts2.Core.MonsterMoves.MonsterMoveStateMachine;
 using MegaCrit.Sts2.Core.Entities.Merchant;
 using MegaCrit.Sts2.Core.Entities.RestSite;
 using MegaCrit.Sts2.Core.Events;
+using MegaCrit.Sts2.Core.Models.Events;
 using MegaCrit.Sts2.Core.Nodes.Events;
+using MegaCrit.Sts2.Core.Nodes.Events.Custom;
 using MegaCrit.Sts2.Core.Nodes.Events.Custom.CrystalSphere;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Map;
@@ -29,6 +31,7 @@ using MegaCrit.Sts2.Core.Nodes.Screens.CardSelection;
 using MegaCrit.Sts2.Core.Nodes.Screens.Map;
 using MegaCrit.Sts2.Core.Nodes.Relics;
 using MegaCrit.Sts2.Core.Nodes.Screens.Overlays;
+using MegaCrit.Sts2.Core.Nodes.Screens.Shops;
 using MegaCrit.Sts2.Core.Nodes.Screens.TreasureRoomRelic;
 using MegaCrit.Sts2.Core.Rewards;
 using MegaCrit.Sts2.Core.Rooms;
@@ -149,6 +152,11 @@ public static partial class McpMod
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMapState(runState);
+            }
+            else if (eventRoom.CanonicalEvent is FakeMerchant)
+            {
+                result["state_type"] = "fake_merchant";
+                result["fake_merchant"] = BuildFakeMerchantState(eventRoom, runState);
             }
             else
             {
@@ -560,6 +568,107 @@ public static partial class McpMod
         }
         state["options"] = options;
 
+        return state;
+    }
+
+    private static Dictionary<string, object?> BuildFakeMerchantState(EventRoom eventRoom, RunState runState)
+    {
+        var state = new Dictionary<string, object?>();
+        // LocalMutableEvent holds the per-player mutable copy with populated inventory;
+        // CanonicalEvent is the shared template which may not have it.
+        var fakeMerchant = (FakeMerchant)(eventRoom.LocalMutableEvent ?? eventRoom.CanonicalEvent);
+
+        state["event_id"] = fakeMerchant.Id.Entry;
+        state["event_name"] = SafeGetText(() => fakeMerchant.Title);
+        state["started_fight"] = fakeMerchant.StartedFight;
+
+        // Find the NFakeMerchant UI node
+        var uiRoom = NEventRoom.Instance;
+        NFakeMerchant? fakeMerchantNode = null;
+        if (uiRoom != null)
+            fakeMerchantNode = FindFirst<NFakeMerchant>(uiRoom);
+
+        if (fakeMerchant.StartedFight)
+        {
+            // After the foul potion fight, merchant is gone — just show proceed
+            state["shop"] = new Dictionary<string, object?>
+            {
+                ["items"] = new List<Dictionary<string, object?>>(),
+                ["can_proceed"] = true
+            };
+            state["message"] = "The fake merchant has been defeated. Proceed to map.";
+            return state;
+        }
+
+        // Auto-open the inventory if the merchant button is still available
+        if (fakeMerchantNode != null)
+        {
+            var inventoryUI = FindFirst<NMerchantInventory>(fakeMerchantNode);
+            if (inventoryUI != null && !inventoryUI.IsOpen)
+            {
+                // ForceClick the merchant button to go through the proper signal chain
+                // (disables proceed button, wires InventoryClosed callback, etc.)
+                var merchantButton = fakeMerchantNode.MerchantButton;
+                if (merchantButton != null && merchantButton.Visible && merchantButton.IsEnabled)
+                    merchantButton.ForceClick();
+            }
+        }
+
+        // Build shop inventory from the FakeMerchant model
+        var shopState = BuildFakeMerchantShopItems(fakeMerchant.Inventory);
+
+        // Proceed button
+        if (fakeMerchantNode != null)
+        {
+            var proceedButton = FindFirst<NProceedButton>(fakeMerchantNode);
+            shopState["can_proceed"] = proceedButton?.IsEnabled ?? false;
+        }
+        else
+        {
+            shopState["can_proceed"] = false;
+        }
+
+        state["shop"] = shopState;
+        return state;
+    }
+
+    private static Dictionary<string, object?> BuildFakeMerchantShopItems(MerchantInventory? inventory)
+    {
+        var state = new Dictionary<string, object?>();
+
+        if (inventory == null)
+        {
+            state["items"] = new List<Dictionary<string, object?>>();
+            state["error"] = "Fake merchant inventory is not ready yet; retry in a moment.";
+            return state;
+        }
+
+        var items = new List<Dictionary<string, object?>>();
+        int index = 0;
+
+        // FakeMerchant only sells relics (no cards, potions, or card removal)
+        foreach (var entry in inventory.RelicEntries)
+        {
+            var item = new Dictionary<string, object?>
+            {
+                ["index"] = index,
+                ["category"] = "relic",
+                ["cost"] = entry.Cost,
+                ["is_stocked"] = entry.IsStocked,
+                ["can_afford"] = entry.EnoughGold
+            };
+            if (entry.Model is { } relic)
+            {
+                item["relic_id"] = relic.Id.Entry;
+                item["relic_name"] = SafeGetText(() => relic.Title);
+                item["relic_description"] = SafeGetText(() => relic.DynamicDescription);
+                item["keywords"] = BuildHoverTips(relic.HoverTipsExcludingRelic);
+            }
+            items.Add(item);
+            index++;
+        }
+
+        state["items"] = items;
         return state;
     }
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -71,7 +71,8 @@ async def get_game_state(format: str = "markdown") -> str:
     """Get the current Slay the Spire 2 game state.
 
     Returns the full game state including player stats, hand, enemies, potions, etc.
-    The state_type field indicates the current screen (combat, map, event, shop, etc.).
+    The state_type field indicates the current screen (combat, map, event, shop,
+    fake_merchant, etc.).
 
     Args:
         format: "markdown" for human-readable output, "json" for structured data.
@@ -121,7 +122,7 @@ async def discard_potion(slot: int) -> str:
 async def proceed_to_map() -> str:
     """Proceed from the current screen to the map.
 
-    Works from: rewards screen, rest site, shop.
+    Works from: rewards screen, rest site, shop, fake merchant.
     Does NOT work for events — use event_choose_option() with the Proceed option's index.
     """
     try:
@@ -287,7 +288,10 @@ async def rest_choose_option(option_index: int) -> str:
 
 @mcp.tool()
 async def shop_purchase(item_index: int) -> str:
-    """[Shop] Purchase an item from the shop.
+    """[Shop / Fake Merchant] Purchase an item from the shop.
+
+    Works for both regular shops (state_type: shop) and the fake merchant
+    event (state_type: fake_merchant). The fake merchant only sells relics.
 
     Args:
         item_index: 0-based index of the item from the shop state.


### PR DESCRIPTION
Handles the fake merchant custom event ("商人？？？"), which was previously showing "No options available" because it uses a custom UI instead of standard event options.

Detects it as `state_type: fake_merchant` with a shop sub-object, reuses existing `shop_purchase` and `proceed` actions. Uses `LocalMutableEvent` instead of `CanonicalEvent` to access the populated inventory.

Fixes #33