### PR TITLE
Add Osty pet state for Necrobinder

### DIFF
--- a/McpMod.Formatting.cs
+++ b/McpMod.Formatting.cs
@@ -42,6 +42,19 @@ public static partial class McpMod
                 string aliveTag = p["is_alive"] is false ? " [DEAD]" : "";
                 string readyTag = p.TryGetValue("is_ready_to_end_turn", out var rdy) && rdy is true ? " [READY]" : "";
                 sb.AppendLine($"- **{p["character"]}**{youTag}{aliveTag}{readyTag} - HP: {p["hp"]}/{p["max_hp"]} | Gold: {p["gold"]}");
+
+                // Show teammate pets inline
+                if (p.TryGetValue("pets", out var tPetsObj) && tPetsObj is List<Dictionary<string, object?>> tPets)
+                {
+                    foreach (var pet in tPets)
+                    {
+                        bool petAlive = pet.TryGetValue("alive", out var pa) && pa is true;
+                        string petStatus = petAlive
+                            ? $"HP: {pet["hp"]}/{pet["max_hp"]} | Block: {pet["block"]}"
+                            : "DEAD";
+                        sb.AppendLine($"  - Pet: **{pet["name"]}** - {petStatus}");
+                    }
+                }
             }
             sb.AppendLine();
         }
@@ -213,6 +226,8 @@ public static partial class McpMod
                     sb.AppendLine($"- *{empty} empty slot(s)*");
                 sb.AppendLine();
             }
+
+            FormatPetsMarkdown(sb, player);
         }
 
         if (battle.TryGetValue("enemies", out var enemiesObj) && enemiesObj is List<Dictionary<string, object?>> enemies && enemies.Count > 0)
@@ -250,6 +265,30 @@ public static partial class McpMod
         FormatPileMarkdown(sb, player, "draw_pile", "draw_pile_count", "Draw Pile", " sorted by rarity");
         FormatPileMarkdown(sb, player, "discard_pile", "discard_pile_count", "Discard Pile");
         FormatPileMarkdown(sb, player, "exhaust_pile", "exhaust_pile_count", "Exhaust Pile");
+    }
+
+    private static void FormatPetsMarkdown(StringBuilder sb, Dictionary<string, object?> player)
+    {
+        if (!player.TryGetValue("pets", out var petsObj)
+            || petsObj is not List<Dictionary<string, object?>> pets
+            || pets.Count == 0)
+            return;
+
+        sb.AppendLine("### Pets");
+        foreach (var pet in pets)
+        {
+            bool alive = pet.TryGetValue("alive", out var a) && a is true;
+            string status = alive
+                ? $"HP: {pet["hp"]}/{pet["max_hp"]} | Block: {pet["block"]}"
+                : "DEAD";
+            sb.AppendLine($"- **{pet["name"]}** (`{pet["id"]}`) - {status}");
+            if (alive)
+            {
+                FormatListSection(sb, "Status", pet, "status",
+                    p => $"  - **{p["name"]}** ({FormatStatusAmount(p["amount"])}): {p["description"]}");
+            }
+        }
+        sb.AppendLine();
     }
 
     private static void FormatPileMarkdown(StringBuilder sb, Dictionary<string, object?> player,

--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -415,6 +415,16 @@ public static partial class McpMod
             if (inCombat)
             {
                 entry["is_ready_to_end_turn"] = CombatManager.Instance.IsPlayerReadyToEndTurn(player);
+
+                // Include pets for teammates (local player's pets are under "player")
+                if (!LocalContext.IsMe(player))
+                {
+                    var pets = BuildPetsState(player);
+                    if (pets.Count > 0)
+                    {
+                        entry["pets"] = pets;
+                    }
+                }
             }
             players.Add(entry);
         }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -34,6 +34,7 @@ using MegaCrit.Sts2.Core.Nodes.Screens.Overlays;
 using MegaCrit.Sts2.Core.Nodes.Screens.Shops;
 using MegaCrit.Sts2.Core.Nodes.Screens.TreasureRoomRelic;
 using MegaCrit.Sts2.Core.Rewards;
+using MegaCrit.Sts2.Core.Models.Monsters;
 using MegaCrit.Sts2.Core.Rooms;
 using MegaCrit.Sts2.Core.Runs;
 
@@ -349,6 +350,13 @@ public static partial class McpMod
                 state["orbs"] = orbs;
                 state["orb_slots"] = orbQueue.Capacity;
                 state["orb_empty_slots"] = orbQueue.Capacity - orbQueue.Orbs.Count;
+            }
+
+            // Pets (Osty for Necrobinder)
+            var pets = BuildPetsState(player);
+            if (pets.Count > 0)
+            {
+                state["pets"] = pets;
             }
         }
 
@@ -1489,5 +1497,30 @@ public static partial class McpMod
             catch { /* skip this power - game engine state may be inconsistent */ }
         }
         return powers;
+    }
+
+    private static List<Dictionary<string, object?>> BuildPetsState(Player player)
+    {
+        var pets = new List<Dictionary<string, object?>>();
+        var combatState = player.PlayerCombatState;
+        if (combatState == null) return pets;
+
+        // Check Osty specifically (Byrdpip/PaelsLegion are cosmetic with no real combat state)
+        var osty = combatState.GetPet<Osty>();
+        if (osty != null)
+        {
+            pets.Add(new Dictionary<string, object?>
+            {
+                ["id"] = osty.Monster?.Id.Entry ?? "OSTY",
+                ["name"] = SafeGetText(() => osty.Monster?.Title) ?? "Otsy",
+                ["alive"] = osty.IsAlive,
+                ["hp"] = osty.CurrentHp,
+                ["max_hp"] = osty.MaxHp,
+                ["block"] = osty.Block,
+                ["status"] = BuildPowersState(osty)
+            });
+        }
+
+        return pets;
     }
 }

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -63,6 +63,17 @@ Always present at the top level (except `menu`). Contains everything about the l
   "orbs": [ /* Orb Objects */ ],   // Defect only; omitted if orb capacity is 0
   "orb_slots": 3,
   "orb_empty_slots": 1,
+  "pets": [                        // Necrobinder only; omitted if no pets
+    {
+      "id": "OSTY",
+      "name": "Otsy",
+      "alive": true,
+      "hp": 12,
+      "max_hp": 12,
+      "block": 0,
+      "status": [ /* Power Objects */ ]
+    }
+  ],
 
   // --- Always present ---
   "status": [ /* Power Objects */ ],
@@ -1079,6 +1090,24 @@ Finish the Crystal Sphere minigame.
       "is_alive": true,
       "is_local": true,
       "is_ready_to_end_turn": false   // Only present during combat
+    },
+    {
+      "character": "The Necrobinder",
+      "hp": 60, "max_hp": 66,
+      "gold": 80,
+      "is_alive": true,
+      "is_local": false,
+      "is_ready_to_end_turn": false,
+      "pets": [                       // Omitted for local player (pets are under top-level "player")
+        {
+          "id": "OSTY",
+          "name": "Otsy",
+          "alive": true,
+          "hp": 12, "max_hp": 12,
+          "block": 0,
+          "status": [ /* Power Objects */ ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Add `pets` array to player state during combat, serializing Osty's HP, max HP, block, alive status, and powers
- Filter to Osty only (Byrdpip/PaelsLegion are cosmetic with 9999 HP and no health bar)
- Dead Osty included with `alive: false` so the controller knows to play Summon cards
- Multiplayer: teammate entries in `players` include their pets; local player's pets are under top-level `player` as usual
- Markdown formatting for both self (### Pets section) and teammates (inline under ## Party)
- Update `raw-full.md` API docs