### PR TITLE
Allow MCP server startup when Harmony patching fails on Linux

### DIFF
--- a/McpMod.cs
+++ b/McpMod.cs
@@ -76,8 +76,8 @@ public static partial class McpMod
     {
         try
         {
-            // Apply Harmony patches (settings UI injection, etc.)
-            new Harmony("com.sts2mcp").PatchAll();
+            // Optional settings UI patches should not block the HTTP bridge itself.
+            TryApplyHarmonyPatches();
 
             // Connect to main thread process frame for action execution
             var tree = (SceneTree)Engine.GetMainLoop();
@@ -102,6 +102,19 @@ public static partial class McpMod
         catch (Exception ex)
         {
             GD.PrintErr($"[STS2 MCP] Failed to start: {ex}");
+        }
+    }
+
+    private static void TryApplyHarmonyPatches()
+    {
+        try
+        {
+            new Harmony("com.sts2mcp").PatchAll();
+        }
+        catch (Exception ex)
+        {
+            GD.PrintErr(
+                $"[STS2 MCP] Harmony patches unavailable; continuing without optional UI injection: {ex}");
         }
     }
 

--- a/STS2_MCP.csproj
+++ b/STS2_MCP.csproj
@@ -6,19 +6,21 @@
     <LangVersion>12.0</LangVersion>
     <!-- Set your STS2 install path here, or pass as: dotnet build -p:STS2GameDir="..." -->
     <STS2GameDir Condition="'$(STS2GameDir)' == ''">D:\SteamLibrary\steamapps\common\Slay the Spire 2</STS2GameDir>
+    <STS2GameDataDir Condition="'$(STS2GameDataDir)' == '' and '$(OS)' == 'Windows_NT'">$(STS2GameDir)/data_sts2_windows_x86_64</STS2GameDataDir>
+    <STS2GameDataDir Condition="'$(STS2GameDataDir)' == '' and '$(OS)' != 'Windows_NT'">$(STS2GameDir)/data_sts2_linuxbsd_x86_64</STS2GameDataDir>
   </PropertyGroup>
 
   <ItemGroup>
     <Reference Include="sts2">
-      <HintPath>$(STS2GameDir)\data_sts2_windows_x86_64\sts2.dll</HintPath>
+      <HintPath>$(STS2GameDataDir)/sts2.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="GodotSharp">
-      <HintPath>$(STS2GameDir)\data_sts2_windows_x86_64\GodotSharp.dll</HintPath>
+      <HintPath>$(STS2GameDataDir)/GodotSharp.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="0Harmony">
-      <HintPath>$(STS2GameDir)\data_sts2_windows_x86_64\0Harmony.dll</HintPath>
+      <HintPath>$(STS2GameDataDir)/0Harmony.dll</HintPath>
       <Private>false</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
### Summary
- catch Harmony patch startup failures so optional UI injection does not abort the HTTP server
- use an OS-specific STS2 data directory so the project can build against Linux installs too

### Validation
Validated locally on native Linux with Slay the Spire 2 0.99.1. Before this change, startup failed with `HarmonyException`, `DllNotFoundException`, and `_Unwind_RaiseException`, and port `15526` never opened. With this change, the MCP server starts successfully.

Closes #59.

Submitted via Codex.
