### PR TITLE
Add block field to multiplayer player state during combat

### DIFF
--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -414,6 +414,7 @@ public static partial class McpMod
             };
             if (inCombat)
             {
+                entry["block"] = player.Creature.Block;
                 entry["is_ready_to_end_turn"] = CombatManager.Instance.IsPlayerReadyToEndTurn(player);
 
                 // Include pets for teammates (local player's pets are under "player")


### PR DESCRIPTION
- Adds `block` field to each player entry in `BuildAllPlayersState` during combat
- Previously, block was exposed for the local player, enemies, and pets, but missing from the multiplayer party list
- One-line additive change: `entry["block"] = player.Creature.Block;`