### PR TITLE
Integrate MCP menu, profile, game-over, FTUE, and timeline handling

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -37,6 +37,7 @@ using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
 using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
+using MegaCrit.Sts2.Core.Nodes.Screens.ProfileScreen;
 using Godot;
 
 namespace STS2_MCP;
@@ -1260,6 +1261,12 @@ public static partial class McpMod
             return ExecuteCharacterSelectMenuOption(charSelect, option, seed);
         }
 
+        var profileScreen = FindFirst<NProfileScreen>(tree.Root);
+        if (profileScreen != null && IsNodeVisible(profileScreen))
+        {
+            return ExecuteProfileSelectMenuOption(profileScreen, option);
+        }
+
         // Main menu — click a menu button
         var mainMenu = FindFirst<NMainMenu>(tree.Root);
         if (mainMenu != null)
@@ -1350,6 +1357,36 @@ public static partial class McpMod
         }
 
         return Error("Not on a menu screen");
+    }
+
+    private static Dictionary<string, object?> ExecuteProfileSelectMenuOption(
+        NProfileScreen profileScreen,
+        string option)
+    {
+        if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var backBtn = GetInstanceFieldValue(profileScreen, "_backButton")
+                ?? FindFirst<NBackButton>(profileScreen);
+            if (backBtn is NClickableControl backClickable &&
+                backClickable.IsEnabled &&
+                IsNodeVisible(backClickable))
+            {
+                backClickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back from profile select" };
+            }
+            return Error("Back button not available on profile select");
+        }
+
+        var normalized = option.ToLowerInvariant();
+        if (normalized.StartsWith("profile_", System.StringComparison.Ordinal))
+            normalized = normalized["profile_".Length..];
+        else if (normalized.StartsWith("slot_", System.StringComparison.Ordinal))
+            normalized = normalized["slot_".Length..];
+
+        if (int.TryParse(normalized, out var profileId))
+            return ExecuteProfileAction("switch", profileId);
+
+        return Error($"Unknown profile select option: {option}. Use: profile_1, profile_2, profile_3, back");
     }
 
     private static Dictionary<string, object?> ExecuteCharacterSelectMenuOption(

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -53,6 +53,10 @@ public static partial class McpMod
         if (player == null)
             return Error("Could not find local player");
 
+        var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
+        if (tree?.Root != null && IsAnyFtueVisible(tree.Root))
+            return Error("Tutorial popup active. Use menu_select advance/proceed before gameplay actions.");
+
         return action switch
         {
             "play_card" => ExecutePlayCard(player, data),
@@ -1130,8 +1134,8 @@ public static partial class McpMod
         }
 
         // Any other FTUE/tutorial popup with a confirm button.
-        var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
-        if (ftue != null && IsNodeVisible(ftue))
+        var ftue = FindVisibleGenericFtue(tree.Root);
+        if (ftue != null)
         {
             if (!string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(option, "proceed", System.StringComparison.OrdinalIgnoreCase))

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -35,6 +35,7 @@ using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
 using Godot;
 
 namespace STS2_MCP;
@@ -1064,6 +1065,60 @@ public static partial class McpMod
         var tree = (Engine.GetMainLoop()) as SceneTree;
         if (tree?.Root == null)
             return Error("Cannot access scene tree");
+
+        // Timeline screen - advance through epoch reveals.
+        var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
+        if (timelineScreen != null && timelineScreen.Visible)
+        {
+            if (string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase))
+            {
+                // Check for inspect screen (epoch detail view) - close it.
+                var inspectScreen = FindFirst<NEpochInspectScreen>(tree.Root);
+                if (inspectScreen != null && inspectScreen.Visible)
+                {
+                    var closeBtn = inspectScreen.GetType().GetField("_closeButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(inspectScreen);
+                    if (closeBtn is NClickableControl closeClickable && closeClickable.IsEnabled)
+                    {
+                        closeClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Closed epoch inspect screen" };
+                    }
+                    inspectScreen.Close();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Closed epoch inspect screen" };
+                }
+
+                // Check for queued unlock screens.
+                if (timelineScreen.IsScreenQueued())
+                {
+                    timelineScreen.OpenQueuedScreen();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Opening queued unlock screen" };
+                }
+
+                // Find an obtained but not-yet-revealed epoch slot to click.
+                var slots = FindAll<NEpochSlot>(timelineScreen);
+                foreach (var slot in slots)
+                {
+                    if (slot.State.ToString() == "Obtained")
+                    {
+                        var onPress = slot.GetType().GetMethod("OnPress", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                        onPress?.Invoke(slot, null);
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicking obtained epoch slot" };
+                    }
+                }
+
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "No more epochs to advance", ["done"] = true };
+            }
+            else if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
+            {
+                var backBtn = timelineScreen.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen);
+                if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+                {
+                    backClickable.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back from timeline" };
+                }
+                return Error("Back button not available on timeline");
+            }
+            return Error($"Unknown timeline option: {option}. Use: advance, back");
+        }
 
         // Main menu — click a menu button
         var mainMenu = FindFirst<NMainMenu>(tree.Root);

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1131,8 +1131,17 @@ public static partial class McpMod
         var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
         if (ftue != null && ftue.Visible)
         {
+            if (!string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(option, "proceed", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return Error($"Unknown tutorial option: {option}. Use: advance, proceed");
+            }
+
             var confirmBtn = ftue.GetType().GetField("_confirmButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(ftue);
-            if (confirmBtn is NClickableControl ftueClickable && ftueClickable.IsEnabled)
+            if (confirmBtn is NClickableControl ftueClickable &&
+                ftueClickable.IsEnabled &&
+                ftueClickable.Visible &&
+                ftueClickable.IsVisibleInTree())
             {
                 ftueClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
@@ -1611,6 +1620,9 @@ public static partial class McpMod
         var btn = GetInstanceFieldValue(owner, fieldName);
         if (btn is NClickableControl clickable)
         {
+            if (!clickable.Visible || !clickable.IsVisibleInTree())
+                return Error(disabledMessage ?? $"Option '{fieldName}' is not available");
+
             if (!clickable.IsEnabled)
                 return Error(disabledMessage ?? $"Option '{fieldName}' is not available");
 

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -33,6 +33,9 @@ using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Entities.Potions;
 using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Runs;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using Godot;
 
 namespace STS2_MCP;
 
@@ -1054,5 +1057,126 @@ public static partial class McpMod
         }
 
         return null;
+    }
+
+    internal static Dictionary<string, object?> ExecuteMenuSelect(string option)
+    {
+        var tree = (Engine.GetMainLoop()) as SceneTree;
+        if (tree?.Root == null)
+            return Error("Cannot access scene tree");
+
+        // Main menu — click a menu button
+        var mainMenu = FindFirst<NMainMenu>(tree.Root);
+        if (mainMenu != null)
+        {
+            // Check if we're on singleplayer submenu
+            var spSubmenu = FindFirst<NSingleplayerSubmenu>(tree.Root);
+            if (spSubmenu != null && spSubmenu.Visible)
+            {
+                if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    var backBtn = spSubmenu.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
+                    if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+                    {
+                        backClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
+                    }
+                    return Error("Back button not available");
+                }
+
+                var fieldName = option.ToLower() switch
+                {
+                    "standard" => "_standardButton",
+                    "daily" => "_dailyButton",
+                    "custom" => "_customButton",
+                    _ => null
+                };
+                if (fieldName == null)
+                    return Error($"Unknown singleplayer option: {option}. Use: standard, daily, custom, back");
+
+                var btn = spSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
+                if (btn is NClickableControl clickable)
+                {
+                    if (!clickable.IsEnabled)
+                        return Error($"Option '{option}' is not available (locked)");
+                    clickable.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {option}" };
+                }
+                return Error($"Could not find button for '{option}'");
+            }
+
+            // Check if we're on character select
+            var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
+            if (charSelect != null && charSelect.Visible)
+            {
+                // "back" clicks the back/unready button
+                if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    var backBtn = charSelect.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect)
+                        ?? charSelect.GetType().GetField("_unreadyButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect);
+                    if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+                    {
+                        backClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
+                    }
+                    return Error("Back button not available");
+                }
+
+                // "confirm" or "embark" clicks the embark button to start the run
+                if (string.Equals(option, "confirm", System.StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(option, "embark", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    var embarkBtn = charSelect.GetType().GetField("_embarkButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect);
+                    if (embarkBtn is NClickableControl embarkClickable && embarkClickable.IsEnabled)
+                    {
+                        embarkClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Embarking on run" };
+                    }
+                    return Error("Embark button not available — select a character first");
+                }
+
+                var buttons = FindAll<NCharacterSelectButton>(charSelect);
+                foreach (var btn in buttons)
+                {
+                    if (btn.Character != null && (
+                        string.Equals(btn.Character.Id.Entry, option, System.StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(SafeGetText(() => btn.Character.Title), option, System.StringComparison.OrdinalIgnoreCase)))
+                    {
+                        if (btn.IsLocked)
+                            return Error($"Character '{option}' is locked");
+                        btn.Select();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {SafeGetText(() => btn.Character.Title)}. Use 'confirm' to embark." };
+                    }
+                }
+                return Error($"Character '{option}' not found. Available: {string.Join(", ", buttons.Where(b => !b.IsLocked).Select(b => b.Character?.Id.Entry))}");
+            }
+
+            // Main menu buttons
+            var menuFieldName = option.ToLower() switch
+            {
+                "singleplayer" => "_singleplayerButton",
+                "multiplayer" => "_multiplayerButton",
+                "compendium" => "_compendiumButton",
+                "timeline" => "_timelineButton",
+                "settings" => "_settingsButton",
+                "continue" => "_continueButton",
+                "quit" => "_quitButton",
+                _ => null
+            };
+            if (menuFieldName == null)
+                return Error($"Unknown menu option: {option}");
+
+            var menuBtn = mainMenu.GetType().GetField(menuFieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mainMenu);
+            if (menuBtn is NClickableControl menuClickable)
+            {
+                if (!menuClickable.IsEnabled)
+                    return Error($"Option '{option}' is not available");
+                menuClickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {option}" };
+            }
+            return Error($"Could not find button for '{option}'");
+        }
+
+        return Error("Not on a menu screen");
     }
 }

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1063,40 +1063,58 @@ public static partial class McpMod
 
     internal static Dictionary<string, object?> ExecuteMenuSelect(string option, string? seed = null)
     {
+        option = option.Trim();
+
+        if (string.IsNullOrEmpty(option))
+            return Error("Missing menu option");
+
         var tree = (Engine.GetMainLoop()) as SceneTree;
         if (tree?.Root == null)
             return Error("Cannot access scene tree");
 
-        // Game over screen
-        var gameOver = FindFirst<NGameOverScreen>(tree.Root);
+        // Game over screen. Prefer the active overlay stack entry so hidden or
+        // preloaded game-over nodes cannot hijack normal menu navigation.
+        var gameOver = NOverlayStack.Instance?.Peek() as NGameOverScreen;
+        gameOver ??= FindAll<NGameOverScreen>(tree.Root).FirstOrDefault(IsNodeVisible);
         if (gameOver != null)
         {
-            var fieldName = option.ToLower() switch
-            {
-                "continue" => "_continueButton",
-                "main_menu" => "_mainMenuButton",
-                _ => null
-            };
-            if (fieldName == null)
-                return Error($"Unknown game over option: {option}. Use: continue, main_menu");
+            if (string.Equals(option, "continue", System.StringComparison.OrdinalIgnoreCase))
+                return Error("Game-over option 'continue' is not actionable. Use: main_menu");
 
-            var btn = gameOver.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(gameOver);
-            if (btn is NClickableControl clickable && clickable.IsEnabled)
+            if (!string.Equals(option, "main_menu", System.StringComparison.OrdinalIgnoreCase))
+                return Error($"Unknown game over option: {option}. Use: main_menu");
+
+            var result = ClickMenuButtonField(gameOver, "_mainMenuButton", "Returning to main menu");
+            if ((string?)result["status"] == "ok")
+                return result;
+
+            var returnMethod = gameOver.GetType().GetMethod(
+                "ReturnToMainMenu",
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+            if (returnMethod != null)
             {
-                clickable.ForceClick();
-                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Clicked {option}" };
+                returnMethod.Invoke(gameOver, null);
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Returning to main menu" };
             }
-            return Error($"Button '{option}' not available");
+
+            return Error("Game-over main_menu option is not available");
         }
 
         // Tutorial/FTUE popup - "Enable Tutorials?" dialog
         var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
         if (tutorialFtue != null && tutorialFtue.Visible)
         {
+            if (!string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(option, "no", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return Error($"Unknown tutorial prompt option: {option}. Use: yes, no");
+            }
+
             var popup = tutorialFtue.GetType().GetField("_verticalPopup", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(tutorialFtue);
             if (popup != null)
             {
-                // "no" clicks No, "yes" clicks Yes, default to No.
                 var isYes = string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase);
                 var btnField = isYes ? "<YesButton>k__BackingField" : "<NoButton>k__BackingField";
                 var btn = popup.GetType().GetField(btnField, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(popup);
@@ -1123,7 +1141,7 @@ public static partial class McpMod
 
         // Timeline screen - advance through epoch reveals.
         var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
-        if (timelineScreen != null && timelineScreen.Visible)
+        if (timelineScreen != null && IsNodeVisible(timelineScreen))
         {
             if (string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(option, "proceed", System.StringComparison.OrdinalIgnoreCase))
@@ -1171,31 +1189,20 @@ public static partial class McpMod
                 }
 
                 // Check for queued unlock screens.
-                if (timelineScreen.IsScreenQueued())
-                {
-                    timelineScreen.OpenQueuedScreen();
-                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Opening queued unlock screen" };
-                }
+                var queuedUnlockResult = TryHandleQueuedTimelineUnlock(timelineScreen);
+                if (queuedUnlockResult != null)
+                    return queuedUnlockResult;
 
-                // Find an obtained epoch slot to click.
-                var slots = FindAll<NEpochSlot>(timelineScreen);
-                foreach (var slot in slots)
-                {
-                    if (slot.State.ToString() == "Obtained")
+                var unrevealedEpochs = GetProgressEpochIdsByState("Obtained", "ObtainedNoSlot");
+                if (unrevealedEpochs.Count > 0)
+                    return new Dictionary<string, object?>
                     {
-                        // Try RevealEpoch to properly transition the state.
-                        var revealMethod = slot.GetType().GetMethod("RevealEpoch", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-                        if (revealMethod != null)
-                        {
-                            revealMethod.Invoke(slot, null);
-                            return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Revealing epoch" };
-                        }
-                        // Fallback: set state directly and open inspect.
-                        slot.SetState(EpochSlotState.Complete);
-                        timelineScreen.OpenInspectScreen(slot, true);
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Force-revealing epoch" };
-                    }
-                }
+                        ["status"] = "ok",
+                        ["message"] = "Epoch unlocks are obtained but not revealed; not forcing timeline reveal from automation",
+                        ["pending_epoch_ids"] = unrevealedEpochs,
+                        ["manual_action_required"] = true,
+                        ["done"] = true
+                    };
 
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "No more epochs to advance", ["done"] = true };
             }
@@ -1224,6 +1231,14 @@ public static partial class McpMod
             return Error($"Unknown timeline option: {option}. Use: advance, back");
         }
 
+        // Character select can outlive or be mounted separately from NMainMenu,
+        // so handle it before main-menu-specific routing.
+        var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
+        if (charSelect != null && IsNodeVisible(charSelect))
+        {
+            return ExecuteCharacterSelectMenuOption(charSelect, option, seed);
+        }
+
         // Main menu — click a menu button
         var mainMenu = FindFirst<NMainMenu>(tree.Root);
         if (mainMenu != null)
@@ -1234,16 +1249,10 @@ public static partial class McpMod
             {
                 if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    var backBtn = spSubmenu.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
-                    if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
-                    {
-                        backClickable.ForceClick();
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
-                    }
-                    return Error("Back button not available");
+                    return ClickMenuButtonField(spSubmenu, "_backButton", "Going back", "Back button is not available");
                 }
 
-                var fieldName = option.ToLower() switch
+                var fieldName = option.ToLowerInvariant() switch
                 {
                     "standard" => "_standardButton",
                     "daily" => "_dailyButton",
@@ -1253,72 +1262,56 @@ public static partial class McpMod
                 if (fieldName == null)
                     return Error($"Unknown singleplayer option: {option}. Use: standard, daily, custom, back");
 
-                var btn = spSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
-                if (btn is NClickableControl clickable)
-                {
-                    if (!clickable.IsEnabled)
-                        return Error($"Option '{option}' is not available (locked)");
-                    clickable.ForceClick();
-                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {option}" };
-                }
-                return Error($"Could not find button for '{option}'");
+                return ClickMenuButtonField(spSubmenu, fieldName, $"Selected {option}", $"Option '{option}' is not available (locked)");
             }
 
-            // Check if we're on character select
-            var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
-            if (charSelect != null && charSelect.Visible)
+            // Check if we're on multiplayer host submenu
+            var mpHostSubmenu = FindFirst<NMultiplayerHostSubmenu>(tree.Root);
+            if (mpHostSubmenu != null && mpHostSubmenu.Visible)
             {
-                // "back" clicks the back/unready button
                 if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    var backBtn = charSelect.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect)
-                        ?? charSelect.GetType().GetField("_unreadyButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect);
-                    if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
-                    {
-                        backClickable.ForceClick();
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
-                    }
-                    return Error("Back button not available");
+                    return ClickMenuButtonField(mpHostSubmenu, "_backButton", "Going back", "Back button is not available");
                 }
 
-                // "confirm" or "embark" clicks the embark button to start the run
-                if (string.Equals(option, "confirm", System.StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(option, "embark", System.StringComparison.OrdinalIgnoreCase))
+                var fieldName = option.ToLowerInvariant() switch
                 {
-                    // Set seed before embarking if provided
-                    if (!string.IsNullOrEmpty(seed) && charSelect.Lobby != null)
-                    {
-                        charSelect.Lobby.SetSeed(seed);
-                    }
+                    "standard" => "_standardButton",
+                    "daily" => "_dailyButton",
+                    "custom" => "_customButton",
+                    _ => null
+                };
+                if (fieldName == null)
+                    return Error($"Unknown multiplayer host option: {option}. Use: standard, daily, custom, back");
 
-                    var embarkBtn = charSelect.GetType().GetField("_embarkButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect);
-                    if (embarkBtn is NClickableControl embarkClickable && embarkClickable.IsEnabled)
-                    {
-                        var msg = string.IsNullOrEmpty(seed) ? "Embarking on run" : $"Embarking on run (seed: {seed})";
-                        embarkClickable.ForceClick();
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = msg };
-                    }
-                    return Error("Embark button not available — select a character first");
-                }
+                return ClickMenuButtonField(mpHostSubmenu, fieldName, $"Selected {option}", $"Option '{option}' is not available (locked)");
+            }
 
-                var buttons = FindAll<NCharacterSelectButton>(charSelect);
-                foreach (var btn in buttons)
+            // Check if we're on multiplayer submenu
+            var mpSubmenu = FindFirst<NMultiplayerSubmenu>(tree.Root);
+            if (mpSubmenu != null && mpSubmenu.Visible)
+            {
+                if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    if (btn.Character != null && (
-                        string.Equals(btn.Character.Id.Entry, option, System.StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(SafeGetText(() => btn.Character.Title), option, System.StringComparison.OrdinalIgnoreCase)))
-                    {
-                        if (btn.IsLocked)
-                            return Error($"Character '{option}' is locked");
-                        btn.Select();
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {SafeGetText(() => btn.Character.Title)}. Use 'confirm' to embark." };
-                    }
+                    return ClickMenuButtonField(mpSubmenu, "_backButton", "Going back", "Back button is not available");
                 }
-                return Error($"Character '{option}' not found. Available: {string.Join(", ", buttons.Where(b => !b.IsLocked).Select(b => b.Character?.Id.Entry))}");
+
+                var fieldName = option.ToLowerInvariant() switch
+                {
+                    "host" => "_hostButton",
+                    "join" => "_joinButton",
+                    "load" => "_loadButton",
+                    "abandon" => "_abandonButton",
+                    _ => null
+                };
+                if (fieldName == null)
+                    return Error($"Unknown multiplayer option: {option}. Use: host, join, load, abandon, back");
+
+                return ClickMenuButtonField(mpSubmenu, fieldName, $"Selected {option}", $"Option '{option}' is not available");
             }
 
             // Main menu buttons
-            var menuFieldName = option.ToLower() switch
+            var menuFieldName = option.ToLowerInvariant() switch
             {
                 "singleplayer" => "_singleplayerButton",
                 "multiplayer" => "_multiplayerButton",
@@ -1332,17 +1325,299 @@ public static partial class McpMod
             if (menuFieldName == null)
                 return Error($"Unknown menu option: {option}");
 
-            var menuBtn = mainMenu.GetType().GetField(menuFieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mainMenu);
-            if (menuBtn is NClickableControl menuClickable)
-            {
-                if (!menuClickable.IsEnabled)
-                    return Error($"Option '{option}' is not available");
-                menuClickable.ForceClick();
-                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {option}" };
-            }
-            return Error($"Could not find button for '{option}'");
+            return ClickMenuButtonField(mainMenu, menuFieldName, $"Selected {option}", $"Option '{option}' is not available");
         }
 
         return Error("Not on a menu screen");
+    }
+
+    private static Dictionary<string, object?> ExecuteCharacterSelectMenuOption(
+        NCharacterSelectScreen charSelect,
+        string option,
+        string? seed)
+    {
+        if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
+                ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
+            if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+            {
+                backClickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
+            }
+            return Error("Back button not available");
+        }
+
+        if (string.Equals(option, "confirm", System.StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(option, "embark", System.StringComparison.OrdinalIgnoreCase))
+        {
+            if (!string.IsNullOrWhiteSpace(seed))
+            {
+                seed = seed.Trim();
+                if (charSelect.Lobby == null)
+                {
+                    return Error("Seeded embark is not supported for standard singleplayer from this API. Seed was not applied and the run was not started.");
+                }
+
+                try
+                {
+                    charSelect.Lobby.SetSeed(seed);
+                }
+                catch (System.Exception ex)
+                {
+                    return Error($"Seeded embark failed before starting the run: {ex.Message}");
+                }
+            }
+
+            var embarkBtn = GetInstanceFieldValue(charSelect, "_embarkButton");
+            if (embarkBtn is NClickableControl embarkClickable && embarkClickable.IsEnabled)
+            {
+                var msg = string.IsNullOrEmpty(seed) ? "Embarking on run" : $"Embarking on run (seed: {seed})";
+                embarkClickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = msg };
+            }
+            return Error("Embark button not available — select a character first");
+        }
+
+        var buttons = FindAll<NCharacterSelectButton>(charSelect);
+        foreach (var btn in buttons)
+        {
+            if (btn.Character != null && (
+                string.Equals(btn.Character.Id.Entry, option, System.StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(SafeGetText(() => btn.Character.Title), option, System.StringComparison.OrdinalIgnoreCase)))
+            {
+                if (btn.IsLocked)
+                    return Error($"Character '{option}' is locked");
+                btn.Select();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Selected {SafeGetText(() => btn.Character.Title)}. Use 'confirm' to embark." };
+            }
+        }
+        return Error($"Character '{option}' not found. Available: {string.Join(", ", buttons.Where(b => !b.IsLocked).Select(b => b.Character?.Id.Entry))}");
+    }
+
+    private static Dictionary<string, object?>? TryHandleQueuedTimelineUnlock(NTimelineScreen timelineScreen)
+    {
+        bool isQueued;
+        try
+        {
+            isQueued = timelineScreen.IsScreenQueued();
+        }
+        catch (System.ObjectDisposedException)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = "Timeline changed while checking queued unlocks; retry after the next state poll",
+                ["retry"] = true
+            };
+        }
+
+        if (!isQueued)
+            return null;
+
+        var queuedScreen = TryPeekQueuedTimelineScreen(timelineScreen);
+        var queuedType = queuedScreen?.GetType().Name ?? "unlock";
+        var queuedEpochIds = GetQueuedTimelineEpochIds(queuedScreen);
+        var alreadyRevealed = queuedEpochIds
+            .Where(id => string.Equals(GetProgressEpochState(id), "Revealed", System.StringComparison.OrdinalIgnoreCase))
+            .Distinct(System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (alreadyRevealed.Count > 0)
+        {
+            var alreadyRevealedSet = new HashSet<string>(alreadyRevealed, System.StringComparer.OrdinalIgnoreCase);
+            var pendingEpochIds = queuedEpochIds
+                .Where(id => !alreadyRevealedSet.Contains(id))
+                .Distinct(System.StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = "Queued timeline unlock references already revealed epochs; not opening it to avoid an invalid unlock path",
+                ["queued_unlock_type"] = queuedType,
+                ["already_revealed_epoch_ids"] = alreadyRevealed,
+                ["pending_epoch_ids"] = pendingEpochIds,
+                ["manual_action_required"] = pendingEpochIds.Count > 0,
+                ["done"] = true
+            };
+        }
+
+        if (string.Equals(queuedType, "NUnlockTimelineScreen", System.StringComparison.Ordinal) &&
+            IsTimelineScreenBusy(timelineScreen))
+        {
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = "Timeline expansion is queued, but the timeline is still animating; retry after the next state poll",
+                ["queued_unlock_type"] = queuedType,
+                ["pending_epoch_ids"] = queuedEpochIds,
+                ["retry"] = true
+            };
+        }
+
+        try
+        {
+            timelineScreen.OpenQueuedScreen();
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = $"Opening queued {queuedType}",
+                ["queued_unlock_type"] = queuedType,
+                ["pending_epoch_ids"] = queuedEpochIds
+            };
+        }
+        catch (System.ObjectDisposedException)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = "Timeline changed before the queued unlock could open; retry after the next state poll",
+                ["queued_unlock_type"] = queuedType,
+                ["retry"] = true
+            };
+        }
+        catch (System.Exception ex)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = $"Skipped queued {queuedType}: {ex.Message}",
+                ["queued_unlock_type"] = queuedType,
+                ["retry"] = true
+            };
+        }
+    }
+
+    private static object? TryPeekQueuedTimelineScreen(NTimelineScreen timelineScreen)
+    {
+        try
+        {
+            var queue = GetInstanceFieldValue(timelineScreen, "_unlockScreens");
+            if (queue == null)
+                return null;
+
+            var count = queue.GetType().GetProperty("Count")?.GetValue(queue) as int?;
+            if (count <= 0)
+                return null;
+
+            return queue.GetType().GetMethod("Peek")?.Invoke(queue, null);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsTimelineScreenBusy(NTimelineScreen timelineScreen)
+    {
+        try
+        {
+            var isUiVisible = GetInstanceFieldValue(timelineScreen, "_isUiVisible") as bool?;
+            if (isUiVisible == false)
+                return true;
+
+            var inputBlocker = GetInstanceFieldValue(timelineScreen, "_inputBlocker") as Control;
+            if (inputBlocker != null && IsNodeVisible(inputBlocker))
+                return true;
+        }
+        catch (System.ObjectDisposedException)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static List<string> GetQueuedTimelineEpochIds(object? queuedScreen)
+    {
+        var ids = new List<string>();
+        if (queuedScreen == null)
+            return ids;
+
+        AddEpochIdsFromObject(GetInstanceFieldValue(queuedScreen, "_epoch"), ids);
+        AddEpochIdsFromObject(GetInstanceFieldValue(queuedScreen, "_unlockedEpochs"), ids);
+        AddEpochIdsFromObject(GetInstanceFieldValue(queuedScreen, "_erasToUnlock"), ids);
+
+        return ids.Distinct(System.StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static void AddEpochIdsFromObject(object? value, List<string> ids)
+    {
+        if (value == null)
+            return;
+
+        if (value is string id)
+        {
+            ids.Add(id);
+            return;
+        }
+
+        if (value is System.Collections.IEnumerable enumerable && value is not string)
+        {
+            foreach (var item in enumerable)
+                AddEpochIdsFromObject(item, ids);
+            return;
+        }
+
+        var model = value.GetType().GetProperty("Model")?.GetValue(value) ?? value;
+        var modelId = model.GetType().GetProperty("Id")?.GetValue(model)?.ToString();
+        if (!string.IsNullOrEmpty(modelId))
+            ids.Add(modelId);
+    }
+
+    private static string? GetProgressEpochState(string epochId)
+    {
+        try
+        {
+            var progress = MegaCrit.Sts2.Core.Saves.SaveManager.Instance?.Progress;
+            return progress?.Epochs
+                .FirstOrDefault(epoch => string.Equals(epoch.Id, epochId, System.StringComparison.OrdinalIgnoreCase))
+                ?.State
+                .ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static List<string> GetProgressEpochIdsByState(params string[] states)
+    {
+        var stateSet = new HashSet<string>(states, System.StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var progress = MegaCrit.Sts2.Core.Saves.SaveManager.Instance?.Progress;
+            if (progress == null)
+                return new List<string>();
+
+            return progress.Epochs
+                .Where(epoch => stateSet.Contains(epoch.State.ToString()))
+                .Select(epoch => epoch.Id)
+                .ToList();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+
+    private static Dictionary<string, object?> ClickMenuButtonField(
+        object owner,
+        string fieldName,
+        string successMessage,
+        string? disabledMessage = null)
+    {
+        var btn = GetInstanceFieldValue(owner, fieldName);
+        if (btn is NClickableControl clickable)
+        {
+            if (!clickable.IsEnabled)
+                return Error(disabledMessage ?? $"Option '{fieldName}' is not available");
+
+            clickable.ForceClick();
+            return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = successMessage };
+        }
+
+        return Error($"Could not find button '{fieldName}'");
     }
 }

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1104,7 +1104,7 @@ public static partial class McpMod
 
         // Tutorial/FTUE popup - "Enable Tutorials?" dialog
         var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
-        if (tutorialFtue != null && tutorialFtue.Visible)
+        if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
         {
             if (!string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(option, "no", System.StringComparison.OrdinalIgnoreCase))
@@ -1118,7 +1118,9 @@ public static partial class McpMod
                 var isYes = string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase);
                 var btnField = isYes ? "<YesButton>k__BackingField" : "<NoButton>k__BackingField";
                 var btn = popup.GetType().GetField(btnField, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(popup);
-                if (btn is NClickableControl clickable && clickable.IsEnabled)
+                if (btn is NClickableControl clickable &&
+                    clickable.IsEnabled &&
+                    IsNodeVisible(clickable))
                 {
                     clickable.ForceClick();
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Tutorials: {(isYes ? "enabled" : "disabled")}" };
@@ -1129,7 +1131,7 @@ public static partial class McpMod
 
         // Any other FTUE/tutorial popup with a confirm button.
         var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
-        if (ftue != null && ftue.Visible)
+        if (ftue != null && IsNodeVisible(ftue))
         {
             if (!string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(option, "proceed", System.StringComparison.OrdinalIgnoreCase))
@@ -1159,10 +1161,12 @@ public static partial class McpMod
             {
                 // Check for timeline tutorial screen (first-time "Proceed" button).
                 var tutorial = FindFirst<NTimelineTutorial>(tree.Root);
-                if (tutorial != null && tutorial.Visible)
+                if (tutorial != null && IsNodeVisible(tutorial))
                 {
                     var ackBtn = tutorial.GetType().GetField("_acknowledgeButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(tutorial);
-                    if (ackBtn is NClickableControl ackClickable && ackClickable.IsEnabled)
+                    if (ackBtn is NClickableControl ackClickable &&
+                        ackClickable.IsEnabled &&
+                        IsNodeVisible(ackClickable))
                     {
                         ackClickable.ForceClick();
                         return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked tutorial proceed button" };
@@ -1171,7 +1175,7 @@ public static partial class McpMod
 
                 // Check for confirm button
                 var confirmBtn = FindFirst<NConfirmButton>(tree.Root);
-                if (confirmBtn != null && confirmBtn.Visible && confirmBtn.IsEnabled)
+                if (confirmBtn != null && IsNodeVisible(confirmBtn) && confirmBtn.IsEnabled)
                 {
                     confirmBtn.ForceClick();
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked confirm button" };
@@ -1179,7 +1183,7 @@ public static partial class McpMod
 
                 // Check for any clickable proceed button
                 var proceedBtn = FindFirst<NProceedButton>(tree.Root);
-                if (proceedBtn != null && proceedBtn.Visible && proceedBtn.IsEnabled)
+                if (proceedBtn != null && IsNodeVisible(proceedBtn) && proceedBtn.IsEnabled)
                 {
                     proceedBtn.ForceClick();
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked proceed button" };
@@ -1187,10 +1191,12 @@ public static partial class McpMod
 
                 // Check for inspect screen (epoch detail view) - close it.
                 var inspectScreen = FindFirst<NEpochInspectScreen>(tree.Root);
-                if (inspectScreen != null && inspectScreen.Visible)
+                if (inspectScreen != null && IsNodeVisible(inspectScreen))
                 {
                     var closeBtn = inspectScreen.GetType().GetField("_closeButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(inspectScreen);
-                    if (closeBtn is NClickableControl closeClickable && closeClickable.IsEnabled)
+                    if (closeBtn is NClickableControl closeClickable &&
+                        closeClickable.IsEnabled &&
+                        IsNodeVisible(closeClickable))
                     {
                         closeClickable.ForceClick();
                         return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Closed epoch inspect screen" };
@@ -1256,7 +1262,7 @@ public static partial class McpMod
         {
             // Check if we're on singleplayer submenu
             var spSubmenu = FindFirst<NSingleplayerSubmenu>(tree.Root);
-            if (spSubmenu != null && spSubmenu.Visible)
+            if (spSubmenu != null && IsNodeVisible(spSubmenu))
             {
                 if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {
@@ -1278,7 +1284,7 @@ public static partial class McpMod
 
             // Check if we're on multiplayer host submenu
             var mpHostSubmenu = FindFirst<NMultiplayerHostSubmenu>(tree.Root);
-            if (mpHostSubmenu != null && mpHostSubmenu.Visible)
+            if (mpHostSubmenu != null && IsNodeVisible(mpHostSubmenu))
             {
                 if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {
@@ -1300,7 +1306,7 @@ public static partial class McpMod
 
             // Check if we're on multiplayer submenu
             var mpSubmenu = FindFirst<NMultiplayerSubmenu>(tree.Root);
-            if (mpSubmenu != null && mpSubmenu.Visible)
+            if (mpSubmenu != null && IsNodeVisible(mpSubmenu))
             {
                 if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
                 {

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1108,7 +1108,7 @@ public static partial class McpMod
         }
 
         // Tutorial/FTUE popup - "Enable Tutorials?" dialog
-        var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
+        var tutorialFtue = FindVisibleAcceptTutorialsFtue(tree.Root);
         if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
         {
             if (!string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase) &&

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -56,7 +56,7 @@ public static partial class McpMod
 
         var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
         if (tree?.Root != null && IsAnyFtueVisible(tree.Root))
-            return Error("Tutorial popup active. Use menu_select advance/proceed before gameplay actions.");
+            return Error("Blocking popup active. Use menu_select with one of the advertised popup options before gameplay actions.");
 
         return action switch
         {
@@ -425,7 +425,7 @@ public static partial class McpMod
     private static Dictionary<string, object?> ExecuteChooseMapNode(Dictionary<string, JsonElement> data)
     {
         var mapScreen = NMapScreen.Instance;
-        if (mapScreen == null || !mapScreen.IsOpen)
+        if (mapScreen == null || (!mapScreen.IsOpen && !IsNodeVisible(mapScreen)))
             return Error("Map screen is not open");
 
         if (!data.TryGetValue("index", out var indexElem))
@@ -1124,8 +1124,7 @@ public static partial class McpMod
                 var btnField = isYes ? "<YesButton>k__BackingField" : "<NoButton>k__BackingField";
                 var btn = popup.GetType().GetField(btnField, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(popup);
                 if (btn is NClickableControl clickable &&
-                    clickable.IsEnabled &&
-                    IsNodeVisible(clickable))
+                    IsControlVisibleOrActionable(clickable))
                 {
                     clickable.ForceClick();
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Tutorials: {(isYes ? "enabled" : "disabled")}" };
@@ -1146,9 +1145,7 @@ public static partial class McpMod
 
             var confirmBtn = ftue.GetType().GetField("_confirmButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(ftue);
             if (confirmBtn is NClickableControl ftueClickable &&
-                ftueClickable.IsEnabled &&
-                ftueClickable.Visible &&
-                ftueClickable.IsVisibleInTree())
+                IsControlVisibleOrActionable(ftueClickable))
             {
                 ftueClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
@@ -1156,6 +1153,12 @@ public static partial class McpMod
 
             return Error("Tutorial popup visible but confirm button is not available; retry after the next state poll");
         }
+
+        // Generic blocking menu popups, such as the first-run warning that appears
+        // over character select on fresh profiles.
+        var verticalPopup = FindVisibleVerticalPopup(tree.Root);
+        if (verticalPopup != null)
+            return ExecuteVisiblePopupOption(verticalPopup, option);
 
         // Timeline screen - advance through epoch reveals.
         var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
@@ -1357,6 +1360,28 @@ public static partial class McpMod
         }
 
         return Error("Not on a menu screen");
+    }
+
+    private static Dictionary<string, object?> ExecuteVisiblePopupOption(NVerticalPopup popup, string option)
+    {
+        var options = GetPopupOptions(popup);
+        foreach (var candidate in options)
+        {
+            if (!string.Equals(candidate.Name, option, System.StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (!IsControlVisibleOrActionable(candidate.Button))
+                return Error($"Popup option '{candidate.Name}' is disabled");
+
+            candidate.Button.ForceClick();
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = $"Selected popup option: {candidate.Name}"
+            };
+        }
+
+        return Error($"Popup option '{option}' is not actionable. Use: {string.Join(", ", options.Select(candidate => candidate.Name))}");
     }
 
     private static Dictionary<string, object?> ExecuteProfileSelectMenuOption(

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1088,6 +1088,38 @@ public static partial class McpMod
             return Error($"Button '{option}' not available");
         }
 
+        // Tutorial/FTUE popup - "Enable Tutorials?" dialog
+        var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
+        if (tutorialFtue != null && tutorialFtue.Visible)
+        {
+            var popup = tutorialFtue.GetType().GetField("_verticalPopup", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(tutorialFtue);
+            if (popup != null)
+            {
+                // "no" clicks No, "yes" clicks Yes, default to No.
+                var isYes = string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase);
+                var btnField = isYes ? "<YesButton>k__BackingField" : "<NoButton>k__BackingField";
+                var btn = popup.GetType().GetField(btnField, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(popup);
+                if (btn is NClickableControl clickable && clickable.IsEnabled)
+                {
+                    clickable.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Tutorials: {(isYes ? "enabled" : "disabled")}" };
+                }
+            }
+            return Error("Tutorial popup visible but buttons not accessible");
+        }
+
+        // Any other FTUE/tutorial popup with a confirm button.
+        var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
+        if (ftue != null && ftue.Visible)
+        {
+            var confirmBtn = ftue.GetType().GetField("_confirmButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(ftue);
+            if (confirmBtn is NClickableControl ftueClickable && ftueClickable.IsEnabled)
+            {
+                ftueClickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
+            }
+        }
+
         // Main menu — click a menu button
         var mainMenu = FindFirst<NMainMenu>(tree.Root);
         if (mainMenu != null)

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1143,15 +1143,14 @@ public static partial class McpMod
                 return Error($"Unknown tutorial option: {option}. Use: advance, proceed");
             }
 
-            var confirmBtn = ftue.GetType().GetField("_confirmButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(ftue);
-            if (confirmBtn is NClickableControl ftueClickable &&
-                IsPopupButtonActionable(ftueClickable))
+            var ftueClickable = FindFtueAdvanceButton(ftue);
+            if (ftueClickable != null)
             {
                 ftueClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
             }
 
-            return Error("Tutorial popup visible but confirm button is not available; retry after the next state poll");
+            return Error("Tutorial popup visible but no actionable advance/proceed control is available; retry after the next state poll");
         }
 
         // Generic blocking menu popups, such as the first-run warning that appears

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1345,7 +1345,15 @@ public static partial class McpMod
             }
 
             // Main menu buttons
-            var menuFieldName = option.ToLowerInvariant() switch
+            var normalizedMainMenuOption = option.ToLowerInvariant();
+            if (normalizedMainMenuOption == "timeline")
+            {
+                var unrevealedEpochs = GetProgressEpochIdsByState("Obtained", "ObtainedNoSlot");
+                if (unrevealedEpochs.Count > 0)
+                    return TimelineUnlocksNeedManualReveal(unrevealedEpochs);
+            }
+
+            var menuFieldName = normalizedMainMenuOption switch
             {
                 "singleplayer" => "_singleplayerButton",
                 "multiplayer" => "_multiplayerButton",
@@ -1363,6 +1371,17 @@ public static partial class McpMod
         }
 
         return Error("Not on a menu screen");
+    }
+
+    private static Dictionary<string, object?> TimelineUnlocksNeedManualReveal(List<string> unrevealedEpochs)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["status"] = "error",
+            ["error"] = "Timeline has obtained epochs that still need to be revealed manually; not opening Timeline because this game state logs invalid unlock-state errors when entered through automation",
+            ["pending_epoch_ids"] = unrevealedEpochs,
+            ["manual_action_required"] = true
+        };
     }
 
     private static Dictionary<string, object?> ExecutePopupOption(

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1059,7 +1059,7 @@ public static partial class McpMod
         return null;
     }
 
-    internal static Dictionary<string, object?> ExecuteMenuSelect(string option)
+    internal static Dictionary<string, object?> ExecuteMenuSelect(string option, string? seed = null)
     {
         var tree = (Engine.GetMainLoop()) as SceneTree;
         if (tree?.Root == null)
@@ -1126,11 +1126,18 @@ public static partial class McpMod
                 if (string.Equals(option, "confirm", System.StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(option, "embark", System.StringComparison.OrdinalIgnoreCase))
                 {
+                    // Set seed before embarking if provided
+                    if (!string.IsNullOrEmpty(seed) && charSelect.Lobby != null)
+                    {
+                        charSelect.Lobby.SetSeed(seed);
+                    }
+
                     var embarkBtn = charSelect.GetType().GetField("_embarkButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(charSelect);
                     if (embarkBtn is NClickableControl embarkClickable && embarkClickable.IsEnabled)
                     {
+                        var msg = string.IsNullOrEmpty(seed) ? "Embarking on run" : $"Embarking on run (seed: {seed})";
                         embarkClickable.ForceClick();
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Embarking on run" };
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = msg };
                     }
                     return Error("Embark button not available — select a character first");
                 }

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1109,7 +1109,7 @@ public static partial class McpMod
 
         // Tutorial/FTUE popup - "Enable Tutorials?" dialog
         var tutorialFtue = FindVisibleAcceptTutorialsFtue(tree.Root);
-        if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
+        if (tutorialFtue != null && IsFtueNodeActive(tutorialFtue))
         {
             if (!string.Equals(option, "yes", System.StringComparison.OrdinalIgnoreCase) &&
                 !string.Equals(option, "no", System.StringComparison.OrdinalIgnoreCase))
@@ -1124,7 +1124,7 @@ public static partial class McpMod
                 var btnField = isYes ? "<YesButton>k__BackingField" : "<NoButton>k__BackingField";
                 var btn = popup.GetType().GetField(btnField, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(popup);
                 if (btn is NClickableControl clickable &&
-                    IsControlVisibleOrActionable(clickable))
+                    IsPopupButtonActionable(clickable))
                 {
                     clickable.ForceClick();
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Tutorials: {(isYes ? "enabled" : "disabled")}" };
@@ -1145,7 +1145,7 @@ public static partial class McpMod
 
             var confirmBtn = ftue.GetType().GetField("_confirmButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(ftue);
             if (confirmBtn is NClickableControl ftueClickable &&
-                IsControlVisibleOrActionable(ftueClickable))
+                IsPopupButtonActionable(ftueClickable))
             {
                 ftueClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
@@ -1158,7 +1158,11 @@ public static partial class McpMod
         // over character select on fresh profiles.
         var verticalPopup = FindVisibleVerticalPopup(tree.Root);
         if (verticalPopup != null)
-            return ExecuteVisiblePopupOption(verticalPopup, option);
+            return ExecutePopupOption(GetPopupOptions(verticalPopup), option);
+
+        var popupButtonOptions = GetVisiblePopupButtonOptions(tree.Root);
+        if (popupButtonOptions.Count > 0)
+            return ExecutePopupOption(popupButtonOptions, option);
 
         // Timeline screen - advance through epoch reveals.
         var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
@@ -1362,15 +1366,16 @@ public static partial class McpMod
         return Error("Not on a menu screen");
     }
 
-    private static Dictionary<string, object?> ExecuteVisiblePopupOption(NVerticalPopup popup, string option)
+    private static Dictionary<string, object?> ExecutePopupOption(
+        List<(string Name, NClickableControl Button)> options,
+        string option)
     {
-        var options = GetPopupOptions(popup);
         foreach (var candidate in options)
         {
             if (!string.Equals(candidate.Name, option, System.StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (!IsControlVisibleOrActionable(candidate.Button))
+            if (!IsPopupButtonActionable(candidate.Button))
                 return Error($"Popup option '{candidate.Name}' is disabled");
 
             candidate.Button.ForceClick();
@@ -1423,7 +1428,7 @@ public static partial class McpMod
         {
             var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
                 ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
-            if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+            if (backBtn is NClickableControl backClickable && IsControlVisibleOrActionable(backClickable))
             {
                 backClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -35,6 +35,7 @@ using MegaCrit.Sts2.Core.GameActions;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using Godot;
 
 namespace STS2_MCP;
@@ -1064,6 +1065,28 @@ public static partial class McpMod
         var tree = (Engine.GetMainLoop()) as SceneTree;
         if (tree?.Root == null)
             return Error("Cannot access scene tree");
+
+        // Game over screen
+        var gameOver = FindFirst<NGameOverScreen>(tree.Root);
+        if (gameOver != null)
+        {
+            var fieldName = option.ToLower() switch
+            {
+                "continue" => "_continueButton",
+                "main_menu" => "_mainMenuButton",
+                _ => null
+            };
+            if (fieldName == null)
+                return Error($"Unknown game over option: {option}. Use: continue, main_menu");
+
+            var btn = gameOver.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(gameOver);
+            if (btn is NClickableControl clickable && clickable.IsEnabled)
+            {
+                clickable.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = $"Clicked {option}" };
+            }
+            return Error($"Button '{option}' not available");
+        }
 
         // Main menu — click a menu button
         var mainMenu = FindFirst<NMainMenu>(tree.Root);

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1146,6 +1146,8 @@ public static partial class McpMod
                 ftueClickable.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Dismissed tutorial popup" };
             }
+
+            return Error("Tutorial popup visible but confirm button is not available; retry after the next state poll");
         }
 
         // Timeline screen - advance through epoch reveals.

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1070,8 +1070,37 @@ public static partial class McpMod
         var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
         if (timelineScreen != null && timelineScreen.Visible)
         {
-            if (string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(option, "advance", System.StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(option, "proceed", System.StringComparison.OrdinalIgnoreCase))
             {
+                // Check for timeline tutorial screen (first-time "Proceed" button).
+                var tutorial = FindFirst<NTimelineTutorial>(tree.Root);
+                if (tutorial != null && tutorial.Visible)
+                {
+                    var ackBtn = tutorial.GetType().GetField("_acknowledgeButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(tutorial);
+                    if (ackBtn is NClickableControl ackClickable && ackClickable.IsEnabled)
+                    {
+                        ackClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked tutorial proceed button" };
+                    }
+                }
+
+                // Check for confirm button
+                var confirmBtn = FindFirst<NConfirmButton>(tree.Root);
+                if (confirmBtn != null && confirmBtn.Visible && confirmBtn.IsEnabled)
+                {
+                    confirmBtn.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked confirm button" };
+                }
+
+                // Check for any clickable proceed button
+                var proceedBtn = FindFirst<NProceedButton>(tree.Root);
+                if (proceedBtn != null && proceedBtn.Visible && proceedBtn.IsEnabled)
+                {
+                    proceedBtn.ForceClick();
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicked proceed button" };
+                }
+
                 // Check for inspect screen (epoch detail view) - close it.
                 var inspectScreen = FindFirst<NEpochInspectScreen>(tree.Root);
                 if (inspectScreen != null && inspectScreen.Visible)
@@ -1093,15 +1122,23 @@ public static partial class McpMod
                     return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Opening queued unlock screen" };
                 }
 
-                // Find an obtained but not-yet-revealed epoch slot to click.
+                // Find an obtained epoch slot to click.
                 var slots = FindAll<NEpochSlot>(timelineScreen);
                 foreach (var slot in slots)
                 {
                     if (slot.State.ToString() == "Obtained")
                     {
-                        var onPress = slot.GetType().GetMethod("OnPress", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                        onPress?.Invoke(slot, null);
-                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Clicking obtained epoch slot" };
+                        // Try RevealEpoch to properly transition the state.
+                        var revealMethod = slot.GetType().GetMethod("RevealEpoch", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                        if (revealMethod != null)
+                        {
+                            revealMethod.Invoke(slot, null);
+                            return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Revealing epoch" };
+                        }
+                        // Fallback: set state directly and open inspect.
+                        slot.SetState(EpochSlotState.Complete);
+                        timelineScreen.OpenInspectScreen(slot, true);
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Force-revealing epoch" };
                     }
                 }
 
@@ -1109,11 +1146,23 @@ public static partial class McpMod
             }
             else if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
             {
+                // Try NBackButton directly on NTimelineScreen
                 var backBtn = timelineScreen.GetType().GetField("_backButton", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen);
-                if (backBtn is NClickableControl backClickable && backClickable.IsEnabled)
+                if (backBtn is NClickableControl backClickable)
                 {
-                    backClickable.ForceClick();
-                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back from timeline" };
+                    if (backClickable.IsEnabled)
+                    {
+                        backClickable.ForceClick();
+                        return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back from timeline" };
+                    }
+                }
+                // Try the submenu stack
+                var stack = timelineScreen.GetType().GetField("_stack", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen);
+                if (stack != null)
+                {
+                    var popMethod = stack.GetType().GetMethod("Pop");
+                    popMethod?.Invoke(stack, null);
+                    return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Popped timeline from stack" };
                 }
                 return Error("Back button not available on timeline");
             }

--- a/McpMod.Formatting.cs
+++ b/McpMod.Formatting.cs
@@ -25,6 +25,18 @@ public static partial class McpMod
             sb.AppendLine();
         }
 
+        if (stateType == "menu")
+        {
+            FormatMenuMarkdown(sb, state);
+            return sb.ToString();
+        }
+
+        if (stateType == "game_over")
+        {
+            FormatGameOverMarkdown(sb, state);
+            return sb.ToString();
+        }
+
         if (state.TryGetValue("message", out var msg) && msg != null)
         {
             sb.AppendLine(msg.ToString());
@@ -173,6 +185,75 @@ public static partial class McpMod
         }
 
         return sb.ToString();
+    }
+
+    private static void FormatMenuMarkdown(StringBuilder sb, Dictionary<string, object?> state)
+    {
+        var screen = state.TryGetValue("menu_screen", out var ms) ? ms?.ToString() ?? "main" : "main";
+        sb.AppendLine($"## Menu: {screen}");
+
+        if (state.TryGetValue("message", out var msg) && msg != null)
+            sb.AppendLine(msg.ToString());
+        sb.AppendLine();
+
+        if (state.TryGetValue("options", out var optionsObj) && optionsObj != null)
+            FormatMenuOptionsMarkdown(sb, optionsObj);
+
+        if (state.TryGetValue("characters", out var charactersObj) &&
+            charactersObj is List<Dictionary<string, object?>> characters &&
+            characters.Count > 0)
+        {
+            sb.AppendLine("### Characters");
+            foreach (var character in characters)
+            {
+                var id = character.GetValueOrDefault("id")?.ToString() ?? "?";
+                var name = character.GetValueOrDefault("name")?.ToString() ?? id;
+                var locked = character.TryGetValue("locked", out var lockedObj) && lockedObj is true ? " (LOCKED)" : "";
+                var hp = character.GetValueOrDefault("hp")?.ToString() ?? "?";
+                var gold = character.GetValueOrDefault("gold")?.ToString() ?? "?";
+                var energy = character.GetValueOrDefault("energy")?.ToString() ?? "?";
+                sb.AppendLine($"- `{id}` **{name}**{locked} - HP: {hp} | Gold: {gold} | Energy: {energy}");
+            }
+            sb.AppendLine();
+            sb.AppendLine("Use `menu_select` with an unlocked character ID or name, then `confirm`/`embark`.");
+            sb.AppendLine();
+        }
+    }
+
+    private static void FormatGameOverMarkdown(StringBuilder sb, Dictionary<string, object?> state)
+    {
+        if (state.TryGetValue("game_over", out var gameOverObj) &&
+            gameOverObj is Dictionary<string, object?> gameOver)
+        {
+            if (gameOver.TryGetValue("message", out var msg) && msg != null)
+                sb.AppendLine(msg.ToString());
+            if (gameOver.TryGetValue("options", out var optionsObj) && optionsObj != null)
+                FormatMenuOptionsMarkdown(sb, optionsObj);
+        }
+    }
+
+    private static void FormatMenuOptionsMarkdown(StringBuilder sb, object optionsObj)
+    {
+        if (optionsObj is List<string> names && names.Count > 0)
+        {
+            sb.AppendLine("### Options");
+            foreach (var name in names)
+                sb.AppendLine($"- `{name}`");
+            sb.AppendLine();
+            return;
+        }
+
+        if (optionsObj is List<Dictionary<string, object?>> options && options.Count > 0)
+        {
+            sb.AppendLine("### Options");
+            foreach (var opt in options)
+            {
+                var name = opt.GetValueOrDefault("name")?.ToString() ?? "?";
+                var enabled = !opt.TryGetValue("enabled", out var enabledObj) || enabledObj is not false;
+                sb.AppendLine($"- `{name}`{(enabled ? "" : " (disabled)")}");
+            }
+            sb.AppendLine();
+        }
     }
 
     private static void FormatBattleMarkdown(StringBuilder sb, Dictionary<string, object?> battle, Dictionary<string, object?>? player)

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -289,6 +289,56 @@ public static partial class McpMod
         }
     }
 
+    private static Node? GetOpenModalNode()
+    {
+        try
+        {
+            return NModalContainer.Instance?.OpenModal as Node;
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsDescendantOf(Node? node, Node ancestor)
+    {
+        try
+        {
+            for (var current = node; current != null && IsLiveNode(current); current = current.GetParent())
+            {
+                if (ReferenceEquals(current, ancestor))
+                    return true;
+            }
+        }
+        catch (ObjectDisposedException) { }
+
+        return false;
+    }
+
+    private static bool IsControlVisibleInOpenModal(NClickableControl? control, Node? openModal = null)
+    {
+        openModal ??= GetOpenModalNode();
+        if (control == null || openModal == null || !IsLiveNode(control) || !IsLiveNode(openModal))
+            return false;
+
+        try
+        {
+            return control.Visible && IsDescendantOf(control, openModal);
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsPopupButtonActionable(NClickableControl? control)
+    {
+        return control != null &&
+               control.IsEnabled &&
+               (IsControlVisibleInTree(control) || IsControlVisibleInOpenModal(control));
+    }
+
     private static bool IsControlVisibleOrActionable(NClickableControl? control)
     {
         return IsControlVisibleInTree(control) && control!.IsEnabled;
@@ -302,10 +352,13 @@ public static partial class McpMod
         if (IsNodeVisible(canvas))
             return true;
 
+        if (ReferenceEquals(GetOpenModalNode(), node))
+            return true;
+
         try
         {
             return GetInstanceFieldValue(node, "_confirmButton") is NClickableControl confirmButton &&
-                   IsControlVisibleInTree(confirmButton);
+                   (IsControlVisibleInTree(confirmButton) || IsControlVisibleInOpenModal(confirmButton));
         }
         catch (ObjectDisposedException)
         {
@@ -316,7 +369,7 @@ public static partial class McpMod
     private static Dictionary<string, object?>? BuildVisibleFtueState(Node root)
     {
         var tutorialFtue = FindVisibleAcceptTutorialsFtue(root);
-        if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
+        if (tutorialFtue != null && IsFtueNodeActive(tutorialFtue))
         {
             return new Dictionary<string, object?>
             {
@@ -357,37 +410,45 @@ public static partial class McpMod
     private static Dictionary<string, object?>? BuildVisiblePopupState(Node root)
     {
         var popup = FindVisibleVerticalPopup(root);
-        if (popup == null)
-            return null;
+        var options = popup != null
+            ? GetPopupOptions(popup)
+            : GetVisiblePopupButtonOptions(root);
 
-        var options = new List<Dictionary<string, object?>>();
-        foreach (var option in GetPopupOptions(popup))
+        var stateOptions = new List<Dictionary<string, object?>>();
+        foreach (var option in options)
         {
-            options.Add(new Dictionary<string, object?>
+            stateOptions.Add(new Dictionary<string, object?>
             {
                 ["name"] = option.Name,
                 ["enabled"] = option.Button.IsEnabled
             });
         }
 
-        if (options.Count == 0)
+        if (stateOptions.Count == 0)
             return null;
 
         return new Dictionary<string, object?>
         {
             ["state_type"] = "menu",
             ["menu_screen"] = "popup",
-            ["message"] = GetVerticalPopupText(popup, "TitleLabel") ?? "Popup active.",
-            ["body"] = GetVerticalPopupText(popup, "BodyLabel"),
-            ["options"] = options
+            ["message"] = popup != null ? GetVerticalPopupText(popup, "TitleLabel") ?? "Popup active." : "Popup active.",
+            ["body"] = popup != null ? GetVerticalPopupText(popup, "BodyLabel") : null,
+            ["options"] = stateOptions
         };
     }
 
     private static MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue? FindVisibleAcceptTutorialsFtue(Node root)
     {
+        var openModal = GetOpenModalNode();
+        if (openModal is MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue openFtue &&
+            IsFtueNodeActive(openFtue))
+        {
+            return openFtue;
+        }
+
         foreach (var ftue in FindAll<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(root))
         {
-            if (IsNodeVisible(ftue))
+            if (IsFtueNodeActive(ftue) || ReferenceEquals(openModal, ftue))
                 return ftue;
         }
         return null;
@@ -400,10 +461,26 @@ public static partial class McpMod
 
     private static NVerticalPopup? FindVisibleVerticalPopup(Node root)
     {
+        var openModal = GetOpenModalNode();
+        if (openModal is NVerticalPopup openPopup && GetPopupOptions(openPopup).Count > 0)
+            return openPopup;
+
+        if (openModal != null)
+        {
+            foreach (var popup in FindAll<NVerticalPopup>(openModal))
+            {
+                if (GetPopupOptions(popup).Count > 0)
+                    return popup;
+            }
+        }
+
         foreach (var popup in FindAll<NVerticalPopup>(root))
         {
-            if (IsNodeVisible(popup) && GetPopupOptions(popup).Count > 0)
+            if ((IsNodeVisible(popup) || (openModal != null && IsDescendantOf(popup, openModal))) &&
+                GetPopupOptions(popup).Count > 0)
+            {
                 return popup;
+            }
         }
         return null;
     }
@@ -416,12 +493,60 @@ public static partial class McpMod
         return options;
     }
 
+    private static List<(string Name, NClickableControl Button)> GetVisiblePopupButtonOptions(Node root)
+    {
+        var options = new List<(string Name, NClickableControl Button)>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var openModal = GetOpenModalNode();
+        if (openModal != null)
+        {
+            foreach (var button in FindAll<NClickableControl>(openModal))
+                AddVisiblePopupButtonOption(options, seen, button, null, openModal);
+        }
+
+        foreach (var button in FindAll<NPopupYesNoButton>(root))
+        {
+            AddVisiblePopupButtonOption(options, seen, button, button.IsYes ? "yes" : "no", null);
+        }
+
+        foreach (var modal in FindAll<NModalContainer>(root))
+        {
+            if (!IsNodeVisible(modal))
+                continue;
+
+            foreach (var button in FindAll<NClickableControl>(modal))
+                AddVisiblePopupButtonOption(options, seen, button, null, null);
+        }
+
+        return options;
+    }
+
+    private static void AddVisiblePopupButtonOption(
+        List<(string Name, NClickableControl Button)> options,
+        HashSet<string> seen,
+        NClickableControl? button,
+        string? fallback,
+        Node? openModal)
+    {
+        if (!(IsControlVisibleInTree(button) || IsControlVisibleInOpenModal(button, openModal)))
+            return;
+
+        var label = button is NPopupYesNoButton popupButton
+            ? GetPopupButtonLabel(popupButton)
+            : GetClickableControlLabel(button!);
+        var name = NormalizeMenuOptionName(label) ?? fallback;
+        if (string.IsNullOrWhiteSpace(name) || !seen.Add(name))
+            return;
+
+        options.Add((name, button!));
+    }
+
     private static void AddPopupOption(
         List<(string Name, NClickableControl Button)> options,
         NPopupYesNoButton? button,
         string fallback)
     {
-        if (!IsControlVisibleInTree(button))
+        if (!IsPopupButtonActionable(button))
             return;
 
         var label = GetPopupButtonLabel(button!);
@@ -439,6 +564,64 @@ public static partial class McpMod
     {
         var label = GetInstanceFieldValue(button, "_label");
         return GetNodeText(label);
+    }
+
+    private static string? GetClickableControlLabel(NClickableControl button)
+    {
+        foreach (var fieldName in new[] { "_label", "_textLabel", "_title", "_buttonLabel" })
+        {
+            var label = GetNodeText(GetInstanceFieldValue(button, fieldName));
+            if (!string.IsNullOrWhiteSpace(label))
+                return label;
+        }
+
+        foreach (var propName in new[] { "Text", "Label", "Title" })
+        {
+            var label = SafeGetText(() => button.GetType().GetProperty(propName)?.GetValue(button));
+            if (!string.IsNullOrWhiteSpace(label))
+                return label;
+        }
+
+        var childText = FindNodeTextRecursive(button);
+        if (!string.IsNullOrWhiteSpace(childText))
+            return childText;
+
+        var nodeName = button.Name.ToString();
+        if (!string.IsNullOrWhiteSpace(nodeName))
+            return nodeName.EndsWith("Button", StringComparison.OrdinalIgnoreCase)
+                ? nodeName[..^"Button".Length]
+                : nodeName;
+
+        return null;
+    }
+
+    private static string? FindNodeTextRecursive(Node start)
+    {
+        if (!IsLiveNode(start))
+            return null;
+
+        var text = GetNodeText(start);
+        if (!string.IsNullOrWhiteSpace(text))
+            return text;
+
+        Godot.Collections.Array<Node> children;
+        try
+        {
+            children = start.GetChildren();
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
+        }
+
+        foreach (var child in children)
+        {
+            text = FindNodeTextRecursive(child);
+            if (!string.IsNullOrWhiteSpace(text))
+                return text;
+        }
+
+        return null;
     }
 
     private static string? GetNodeText(object? node)
@@ -476,6 +659,17 @@ public static partial class McpMod
 
     private static Node? FindVisibleGenericFtue(Node start)
     {
+        if (ReferenceEquals(start, (Godot.Engine.GetMainLoop() as SceneTree)?.Root))
+        {
+            var openModal = GetOpenModalNode();
+            if (openModal != null)
+            {
+                var openFtue = FindVisibleGenericFtue(openModal);
+                if (openFtue != null)
+                    return openFtue;
+            }
+        }
+
         if (!IsLiveNode(start))
             return null;
 

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -265,4 +265,80 @@ public static partial class McpMod
             return false;
         }
     }
+
+    private static Dictionary<string, object?>? BuildVisibleFtueState(Node root)
+    {
+        var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(root);
+        if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
+        {
+            return new Dictionary<string, object?>
+            {
+                ["state_type"] = "menu",
+                ["menu_screen"] = "tutorial_prompt",
+                ["message"] = "Enable Tutorials? Choose yes or no.",
+                ["options"] = new List<Dictionary<string, object?>>
+                {
+                    new() { ["name"] = "no", ["enabled"] = true },
+                    new() { ["name"] = "yes", ["enabled"] = true }
+                }
+            };
+        }
+
+        var ftue = FindVisibleGenericFtue(root);
+        if (ftue != null)
+        {
+            return new Dictionary<string, object?>
+            {
+                ["state_type"] = "menu",
+                ["menu_screen"] = "tutorial",
+                ["message"] = "Tutorial popup active. Use advance to dismiss.",
+                ["options"] = new List<Dictionary<string, object?>>
+                {
+                    new() { ["name"] = "advance", ["enabled"] = true },
+                    new() { ["name"] = "proceed", ["enabled"] = true }
+                }
+            };
+        }
+
+        return null;
+    }
+
+    private static bool IsAnyFtueVisible(Node root)
+    {
+        return BuildVisibleFtueState(root) != null;
+    }
+
+    private static Node? FindVisibleGenericFtue(Node start)
+    {
+        if (!IsLiveNode(start))
+            return null;
+
+        var typeName = start.GetType().FullName ?? "";
+        if (typeName.StartsWith("MegaCrit.Sts2.Core.Nodes.Ftue.", StringComparison.Ordinal) &&
+            !typeName.EndsWith(".NAcceptTutorialsFtue", StringComparison.Ordinal) &&
+            start is CanvasItem canvas &&
+            IsNodeVisible(canvas))
+        {
+            return start;
+        }
+
+        Godot.Collections.Array<Node> children;
+        try
+        {
+            children = start.GetChildren();
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
+        }
+
+        foreach (var child in children)
+        {
+            var val = FindVisibleGenericFtue(child);
+            if (val != null)
+                return val;
+        }
+
+        return null;
+    }
 }

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -275,19 +275,23 @@ public static partial class McpMod
         return mapScreen != null && (mapScreen.IsOpen || IsNodeVisible(mapScreen));
     }
 
-    private static bool IsControlVisibleOrActionable(NClickableControl? control)
+    private static bool IsControlVisibleInTree(NClickableControl? control)
     {
         try
         {
             return control != null &&
                    IsLiveNode(control) &&
-                   control.IsEnabled &&
-                   (IsNodeVisible(control) || control.Visible);
+                   IsNodeVisible(control);
         }
         catch (ObjectDisposedException)
         {
             return false;
         }
+    }
+
+    private static bool IsControlVisibleOrActionable(NClickableControl? control)
+    {
+        return IsControlVisibleInTree(control) && control!.IsEnabled;
     }
 
     private static bool IsFtueNodeActive(Node node)
@@ -300,9 +304,8 @@ public static partial class McpMod
 
         try
         {
-            return canvas.Visible &&
-                   GetInstanceFieldValue(node, "_confirmButton") is NClickableControl confirmButton &&
-                   IsControlVisibleOrActionable(confirmButton);
+            return GetInstanceFieldValue(node, "_confirmButton") is NClickableControl confirmButton &&
+                   IsControlVisibleInTree(confirmButton);
         }
         catch (ObjectDisposedException)
         {
@@ -399,7 +402,7 @@ public static partial class McpMod
     {
         foreach (var popup in FindAll<NVerticalPopup>(root))
         {
-            if ((IsNodeVisible(popup) || popup.Visible) && GetPopupOptions(popup).Count > 0)
+            if (IsNodeVisible(popup) && GetPopupOptions(popup).Count > 0)
                 return popup;
         }
         return null;
@@ -418,7 +421,7 @@ public static partial class McpMod
         NPopupYesNoButton? button,
         string fallback)
     {
-        if (!IsControlVisibleOrActionable(button))
+        if (!IsControlVisibleInTree(button))
             return;
 
         var label = GetPopupButtonLabel(button!);

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -334,9 +334,18 @@ public static partial class McpMod
 
     private static bool IsPopupButtonActionable(NClickableControl? control)
     {
-        return control != null &&
-               control.IsEnabled &&
-               (IsControlVisibleInTree(control) || IsControlVisibleInOpenModal(control));
+        if (control == null || !IsLiveNode(control))
+            return false;
+
+        try
+        {
+            return control.IsEnabled &&
+                   (IsControlVisibleInTree(control) || IsControlVisibleInOpenModal(control));
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
     }
 
     private static bool IsControlVisibleOrActionable(NClickableControl? control)

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -7,6 +7,9 @@ using Godot;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
+using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
+using MegaCrit.Sts2.Core.Nodes.Screens.Map;
 
 namespace STS2_MCP;
 
@@ -266,6 +269,47 @@ public static partial class McpMod
         }
     }
 
+    private static bool IsMapScreenOpenOrVisible()
+    {
+        var mapScreen = NMapScreen.Instance;
+        return mapScreen != null && (mapScreen.IsOpen || IsNodeVisible(mapScreen));
+    }
+
+    private static bool IsControlVisibleOrActionable(NClickableControl? control)
+    {
+        try
+        {
+            return control != null &&
+                   IsLiveNode(control) &&
+                   control.IsEnabled &&
+                   (IsNodeVisible(control) || control.Visible);
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsFtueNodeActive(Node node)
+    {
+        if (node is not CanvasItem canvas || !IsLiveNode(node))
+            return false;
+
+        if (IsNodeVisible(canvas))
+            return true;
+
+        try
+        {
+            return canvas.Visible &&
+                   GetInstanceFieldValue(node, "_confirmButton") is NClickableControl confirmButton &&
+                   IsControlVisibleOrActionable(confirmButton);
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
     private static Dictionary<string, object?>? BuildVisibleFtueState(Node root)
     {
         var tutorialFtue = FindVisibleAcceptTutorialsFtue(root);
@@ -300,7 +344,40 @@ public static partial class McpMod
             };
         }
 
+        var popup = BuildVisiblePopupState(root);
+        if (popup != null)
+            return popup;
+
         return null;
+    }
+
+    private static Dictionary<string, object?>? BuildVisiblePopupState(Node root)
+    {
+        var popup = FindVisibleVerticalPopup(root);
+        if (popup == null)
+            return null;
+
+        var options = new List<Dictionary<string, object?>>();
+        foreach (var option in GetPopupOptions(popup))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = option.Name,
+                ["enabled"] = option.Button.IsEnabled
+            });
+        }
+
+        if (options.Count == 0)
+            return null;
+
+        return new Dictionary<string, object?>
+        {
+            ["state_type"] = "menu",
+            ["menu_screen"] = "popup",
+            ["message"] = GetVerticalPopupText(popup, "TitleLabel") ?? "Popup active.",
+            ["body"] = GetVerticalPopupText(popup, "BodyLabel"),
+            ["options"] = options
+        };
     }
 
     private static MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue? FindVisibleAcceptTutorialsFtue(Node root)
@@ -318,6 +395,82 @@ public static partial class McpMod
         return BuildVisibleFtueState(root) != null;
     }
 
+    private static NVerticalPopup? FindVisibleVerticalPopup(Node root)
+    {
+        foreach (var popup in FindAll<NVerticalPopup>(root))
+        {
+            if ((IsNodeVisible(popup) || popup.Visible) && GetPopupOptions(popup).Count > 0)
+                return popup;
+        }
+        return null;
+    }
+
+    private static List<(string Name, NClickableControl Button)> GetPopupOptions(NVerticalPopup popup)
+    {
+        var options = new List<(string Name, NClickableControl Button)>();
+        AddPopupOption(options, popup.YesButton, "yes");
+        AddPopupOption(options, popup.NoButton, "no");
+        return options;
+    }
+
+    private static void AddPopupOption(
+        List<(string Name, NClickableControl Button)> options,
+        NPopupYesNoButton? button,
+        string fallback)
+    {
+        if (!IsControlVisibleOrActionable(button))
+            return;
+
+        var label = GetPopupButtonLabel(button!);
+        var name = NormalizeMenuOptionName(label) ?? fallback;
+        options.Add((name, button!));
+    }
+
+    private static string? GetVerticalPopupText(NVerticalPopup popup, string propertyName)
+    {
+        var label = popup.GetType().GetProperty(propertyName)?.GetValue(popup);
+        return GetNodeText(label);
+    }
+
+    private static string? GetPopupButtonLabel(NPopupYesNoButton button)
+    {
+        var label = GetInstanceFieldValue(button, "_label");
+        return GetNodeText(label);
+    }
+
+    private static string? GetNodeText(object? node)
+    {
+        if (node == null)
+            return null;
+
+        foreach (var propName in new[] { "Text", "BbcodeText" })
+        {
+            var text = SafeGetText(() => node.GetType().GetProperty(propName)?.GetValue(node));
+            if (!string.IsNullOrWhiteSpace(text))
+                return text;
+        }
+
+        return null;
+    }
+
+    private static string? NormalizeMenuOptionName(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        var sb = new StringBuilder();
+        foreach (var ch in StripRichTextTags(text).Trim().ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+                sb.Append(ch);
+            else if (sb.Length > 0 && sb[^1] != '_')
+                sb.Append('_');
+        }
+
+        var normalized = sb.ToString().Trim('_');
+        return normalized.Length == 0 ? null : normalized;
+    }
+
     private static Node? FindVisibleGenericFtue(Node start)
     {
         if (!IsLiveNode(start))
@@ -326,8 +479,7 @@ public static partial class McpMod
         var typeName = start.GetType().FullName ?? "";
         if (typeName.StartsWith("MegaCrit.Sts2.Core.Nodes.Ftue.", StringComparison.Ordinal) &&
             !typeName.EndsWith(".NAcceptTutorialsFtue", StringComparison.Ordinal) &&
-            start is CanvasItem canvas &&
-            IsNodeVisible(canvas))
+            IsFtueNodeActive(start))
         {
             return start;
         }

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -268,7 +268,7 @@ public static partial class McpMod
 
     private static Dictionary<string, object?>? BuildVisibleFtueState(Node root)
     {
-        var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(root);
+        var tutorialFtue = FindVisibleAcceptTutorialsFtue(root);
         if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
         {
             return new Dictionary<string, object?>
@@ -300,6 +300,16 @@ public static partial class McpMod
             };
         }
 
+        return null;
+    }
+
+    private static MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue? FindVisibleAcceptTutorialsFtue(Node root)
+    {
+        foreach (var ftue in FindAll<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(root))
+        {
+            if (IsNodeVisible(ftue))
+                return ftue;
+        }
         return null;
     }
 

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -124,7 +124,7 @@ public static partial class McpMod
         try
         {
             var btn = GetInstanceFieldValue(owner, fieldName);
-            if (btn is Control ctrl && ctrl.Visible)
+            if (btn is Control ctrl && IsNodeVisible(ctrl))
             {
                 var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
                 options.Add(new Dictionary<string, object?>

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -258,7 +258,7 @@ public static partial class McpMod
     {
         try
         {
-            return node != null && IsLiveNode(node) && node.Visible;
+            return node != null && IsLiveNode(node) && node.Visible && node.IsVisibleInTree();
         }
         catch (ObjectDisposedException)
         {

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -97,10 +97,50 @@ public static partial class McpMod
         return new Dictionary<string, object?> { ["status"] = "error", ["error"] = message };
     }
 
+    private static object? GetInstanceFieldValue(object source, string fieldName)
+    {
+        const System.Reflection.BindingFlags Flags =
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.DeclaredOnly;
+
+        for (var type = source.GetType(); type != null; type = type.BaseType)
+        {
+            var field = type.GetField(fieldName, Flags);
+            if (field != null)
+                return field.GetValue(source);
+        }
+
+        return null;
+    }
+
+    private static void AddMenuOptionIfVisible(
+        List<Dictionary<string, object?>> options,
+        object owner,
+        string fieldName,
+        string label)
+    {
+        try
+        {
+            var btn = GetInstanceFieldValue(owner, fieldName);
+            if (btn is Control ctrl && ctrl.Visible)
+            {
+                var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
+                options.Add(new Dictionary<string, object?>
+                {
+                    ["name"] = label,
+                    ["enabled"] = isEnabled ?? true
+                });
+            }
+        }
+        catch { }
+    }
+
     internal static List<T> FindAll<T>(Node start) where T : Node
     {
         var list = new List<T>();
-        if (GodotObject.IsInstanceValid(start))
+        if (IsLiveNode(start))
             FindAllRecursive(start, list);
         return list;
     }
@@ -124,12 +164,16 @@ public static partial class McpMod
 
     private static void FindAllRecursive<T>(Node node, List<T> found) where T : Node
     {
-        if (!GodotObject.IsInstanceValid(node))
+        if (!IsLiveNode(node))
             return;
         if (node is T item)
             found.Add(item);
-        foreach (var child in node.GetChildren())
-            FindAllRecursive(child, found);
+        try
+        {
+            foreach (var child in node.GetChildren())
+                FindAllRecursive(child, found);
+        }
+        catch (ObjectDisposedException) { }
     }
 
     private static List<Dictionary<string, object?>> BuildHoverTips(IEnumerable<IHoverTip> tips)
@@ -176,15 +220,49 @@ public static partial class McpMod
 
     internal static T? FindFirst<T>(Node start) where T : Node
     {
-        if (!GodotObject.IsInstanceValid(start))
+        if (!IsLiveNode(start))
             return null;
         if (start is T result)
             return result;
-        foreach (var child in start.GetChildren())
+        Godot.Collections.Array<Node> children;
+        try
+        {
+            children = start.GetChildren();
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
+        }
+
+        foreach (var child in children)
         {
             var val = FindFirst<T>(child);
             if (val != null) return val;
         }
         return null;
+    }
+
+    internal static bool IsLiveNode(Node? node)
+    {
+        try
+        {
+            return node != null && GodotObject.IsInstanceValid(node) && !node.IsQueuedForDeletion();
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    internal static bool IsNodeVisible(CanvasItem? node)
+    {
+        try
+        {
+            return node != null && IsLiveNode(node) && node.Visible;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
     }
 }

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -387,6 +387,7 @@ public static partial class McpMod
         var ftue = FindVisibleGenericFtue(root);
         if (ftue != null)
         {
+            var canAdvance = FindFtueAdvanceButton(ftue) != null;
             return new Dictionary<string, object?>
             {
                 ["state_type"] = "menu",
@@ -394,8 +395,8 @@ public static partial class McpMod
                 ["message"] = "Tutorial popup active. Use advance to dismiss.",
                 ["options"] = new List<Dictionary<string, object?>>
                 {
-                    new() { ["name"] = "advance", ["enabled"] = true },
-                    new() { ["name"] = "proceed", ["enabled"] = true }
+                    new() { ["name"] = "advance", ["enabled"] = canAdvance },
+                    new() { ["name"] = "proceed", ["enabled"] = canAdvance }
                 }
             };
         }
@@ -696,6 +697,55 @@ public static partial class McpMod
             var val = FindVisibleGenericFtue(child);
             if (val != null)
                 return val;
+        }
+
+        return null;
+    }
+
+    private static NClickableControl? FindFtueAdvanceButton(Node ftue)
+    {
+        foreach (var fieldName in new[]
+        {
+            "_confirmButton",
+            "_advanceButton",
+            "_nextButton",
+            "_proceedButton",
+            "_acknowledgeButton",
+            "_arrowButton",
+            "_rightArrowButton",
+            "_rightButton"
+        })
+        {
+            if (GetInstanceFieldValue(ftue, fieldName) is NClickableControl fieldButton &&
+                IsPopupButtonActionable(fieldButton))
+            {
+                return fieldButton;
+            }
+        }
+
+        try
+        {
+            foreach (var field in ftue.GetType().GetFields(
+                         System.Reflection.BindingFlags.Public |
+                         System.Reflection.BindingFlags.NonPublic |
+                         System.Reflection.BindingFlags.Instance))
+            {
+                if (field.GetValue(ftue) is NClickableControl fieldButton &&
+                    IsPopupButtonActionable(fieldButton))
+                {
+                    return fieldButton;
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            return null;
+        }
+
+        foreach (var button in FindAll<NClickableControl>(ftue))
+        {
+            if (IsPopupButtonActionable(button))
+                return button;
         }
 
         return null;

--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -68,7 +68,7 @@ public static partial class McpMod
         // Same overlay-first detection logic as singleplayer
         var topOverlay = NOverlayStack.Instance?.Peek();
         var currentRoom = runState.CurrentRoom;
-        bool mapIsOpen = NMapScreen.Instance is { IsOpen: true };
+        bool mapIsOpen = IsMapScreenOpenOrVisible();
 
         if (topOverlay is NCardGridSelectionScreen cardSelectScreen)
         {
@@ -136,7 +136,7 @@ public static partial class McpMod
             else
             {
                 // After combat ends - reward/card overlays are caught by top-level checks above.
-                if (NMapScreen.Instance is { IsOpen: true })
+                if (IsMapScreenOpenOrVisible())
                 {
                     result["state_type"] = "map";
                     result["map"] = BuildMultiplayerMapState(runState);
@@ -150,7 +150,7 @@ public static partial class McpMod
         }
         else if (currentRoom is EventRoom eventRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMultiplayerMapState(runState);
@@ -173,7 +173,7 @@ public static partial class McpMod
         }
         else if (currentRoom is MerchantRoom merchantRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMultiplayerMapState(runState);
@@ -192,7 +192,7 @@ public static partial class McpMod
         }
         else if (currentRoom is RestSiteRoom restSiteRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMultiplayerMapState(runState);
@@ -205,7 +205,7 @@ public static partial class McpMod
         }
         else if (currentRoom is TreasureRoom treasureRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMultiplayerMapState(runState);

--- a/McpMod.Profile.cs
+++ b/McpMod.Profile.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using Godot;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.ProfileScreen;
+using MegaCrit.Sts2.Core.Runs;
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+
+namespace STS2_MCP;
+
+public static partial class McpMod
+{
+    private static void HandleGetProfile(HttpListenerResponse response)
+    {
+        try
+        {
+            var dataTask = RunOnMainThread(BuildProfile);
+            SendJson(response, dataTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            SendError(response, 500, $"Failed to build profile: {ex.Message}");
+        }
+    }
+
+    private static void HandleGetProfiles(HttpListenerResponse response)
+    {
+        try
+        {
+            var dataTask = RunOnMainThread(BuildProfilesSummary);
+            SendJson(response, dataTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            SendError(response, 500, $"Failed to get profiles: {ex.Message}");
+        }
+    }
+
+    private static void HandlePostProfiles(HttpListenerRequest request, HttpListenerResponse response)
+    {
+        string body;
+        using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
+            body = reader.ReadToEnd();
+
+        Dictionary<string, JsonElement>? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(body);
+        }
+        catch
+        {
+            SendError(response, 400, "Invalid JSON");
+            return;
+        }
+
+        if (parsed == null || !parsed.TryGetValue("action", out var actionElem))
+        {
+            SendError(response, 400, "Missing 'action' field. Use: switch, delete");
+            return;
+        }
+
+        string action = actionElem.GetString() ?? "";
+        int profileId = parsed.TryGetValue("profile_id", out var idElem) && idElem.ValueKind == JsonValueKind.Number
+            ? idElem.GetInt32()
+            : 0;
+
+        try
+        {
+            var resultTask = RunOnMainThread(() => ExecuteProfileAction(action, profileId));
+            SendJson(response, resultTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            SendError(response, 500, $"Profile action failed: {ex.Message}");
+        }
+    }
+
+    private static Dictionary<string, object?> BuildProfilesSummary()
+    {
+        var sm = SaveManager.Instance;
+        if (sm == null)
+            return Error("Save manager is not available");
+
+        var profiles = new List<Dictionary<string, object?>>();
+        for (int i = 1; i <= 3; i++)
+        {
+            var profileData = new Dictionary<string, object?>
+            {
+                ["id"] = i,
+                ["is_current"] = i == sm.CurrentProfileId,
+            };
+
+            try
+            {
+                var path = ProgressSaveManager.GetProgressPathForProfile(i);
+                profileData["has_data"] = File.Exists(path);
+                profileData["path"] = path;
+            }
+            catch
+            {
+                profileData["has_data"] = false;
+            }
+
+            profiles.Add(profileData);
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["current_profile_id"] = sm.CurrentProfileId,
+            ["profiles"] = profiles
+        };
+    }
+
+    private static Dictionary<string, object?> ExecuteProfileAction(string action, int profileId)
+    {
+        var sm = SaveManager.Instance;
+        if (sm == null)
+            return Error("Save manager is not available");
+        if (profileId is < 1 or > 3)
+            return Error("profile_id must be 1-3");
+
+        var normalizedAction = action.Trim().ToLowerInvariant();
+
+        if (normalizedAction == "switch")
+        {
+            if (RunManager.Instance?.IsInProgress == true)
+                return Error("Cannot switch profiles during a run");
+
+            var tree = Engine.GetMainLoop() as SceneTree;
+            if (tree?.Root != null)
+            {
+                if (TrySwitchProfileViaOpenScreen(tree.Root, profileId))
+                {
+                    return new Dictionary<string, object?>
+                    {
+                        ["status"] = "ok",
+                        ["message"] = $"Switch requested for profile {profileId} (via UI)",
+                        ["target_profile_id"] = profileId,
+                        ["current_profile_id"] = sm.CurrentProfileId
+                    };
+                }
+
+                var mainMenu = FindFirst<NMainMenu>(tree.Root);
+                if (mainMenu != null && IsNodeVisible(mainMenu))
+                {
+                    mainMenu.OpenProfileScreen();
+                    return new Dictionary<string, object?>
+                    {
+                        ["status"] = "ok",
+                        ["message"] = "Opened profile screen. Send switch again to select profile."
+                    };
+                }
+            }
+
+            sm.SwitchProfileId(profileId);
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = $"Switched to profile {profileId} (requires restart)",
+                ["current_profile_id"] = sm.CurrentProfileId
+            };
+        }
+
+        if (normalizedAction == "delete")
+        {
+            if (profileId == sm.CurrentProfileId)
+                return Error("Cannot delete the active profile");
+
+            sm.DeleteProfile(profileId);
+            return new Dictionary<string, object?>
+            {
+                ["status"] = "ok",
+                ["message"] = $"Deleted profile {profileId}"
+            };
+        }
+
+        return Error($"Unknown action: {action}. Use: switch, delete");
+    }
+
+    private static bool TrySwitchProfileViaOpenScreen(Node root, int profileId)
+    {
+        var profileScreen = FindFirst<NProfileScreen>(root);
+        if (profileScreen == null || !IsNodeVisible(profileScreen))
+            return false;
+
+        var buttons = GetInstanceFieldValue(profileScreen, "_profileButtons") as System.Collections.IEnumerable;
+        if (buttons == null)
+            return false;
+
+        foreach (var btn in buttons)
+        {
+            var btnId = GetInstanceFieldValue(btn, "_profileId");
+            if (btnId is not int id || id != profileId)
+                continue;
+
+            var switchMethod = btn.GetType().GetMethod(
+                "SwitchToThisProfile",
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+            switchMethod?.Invoke(btn, null);
+            return switchMethod != null;
+        }
+
+        return false;
+    }
+
+    internal static object BuildProfile()
+    {
+        var progress = SaveManager.Instance?.Progress;
+        if (progress == null)
+            return new Dictionary<string, object?> { ["error"] = "No profile data available." };
+
+        var result = new Dictionary<string, object?>();
+
+        var characters = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.CharacterStats)
+        {
+            var stats = kv.Value;
+            characters.Add(new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key.Entry,
+                ["max_ascension"] = stats.MaxAscension,
+                ["preferred_ascension"] = stats.PreferredAscension,
+                ["total_wins"] = stats.TotalWins,
+                ["total_losses"] = stats.TotalLosses,
+                ["fastest_win_time"] = stats.FastestWinTime,
+                ["best_win_streak"] = stats.BestWinStreak,
+                ["current_win_streak"] = stats.CurrentWinStreak,
+                ["playtime"] = stats.Playtime
+            });
+        }
+        result["characters"] = characters;
+
+        var cards = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.CardStats)
+        {
+            var stats = kv.Value;
+            cards.Add(new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key.Entry,
+                ["times_picked"] = stats.TimesPicked,
+                ["times_skipped"] = stats.TimesSkipped,
+                ["times_won"] = stats.TimesWon,
+                ["times_lost"] = stats.TimesLost
+            });
+        }
+        result["card_stats"] = cards;
+
+        var encounters = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.EncounterStats)
+        {
+            var enc = new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key.Entry,
+                ["total_wins"] = kv.Value.TotalWins,
+                ["total_losses"] = kv.Value.TotalLosses
+            };
+            var fightStats = new List<Dictionary<string, object?>>();
+            foreach (var fs in kv.Value.FightStats)
+            {
+                fightStats.Add(new Dictionary<string, object?>
+                {
+                    ["character"] = fs.Character.Entry,
+                    ["wins"] = fs.Wins,
+                    ["losses"] = fs.Losses
+                });
+            }
+            if (fightStats.Count > 0)
+                enc["by_character"] = fightStats;
+            encounters.Add(enc);
+        }
+        result["encounter_stats"] = encounters;
+
+        var enemies = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.EnemyStats)
+        {
+            var enemy = new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key.Entry,
+                ["total_wins"] = kv.Value.TotalWins,
+                ["total_losses"] = kv.Value.TotalLosses
+            };
+            var fightStats = new List<Dictionary<string, object?>>();
+            foreach (var fs in kv.Value.FightStats)
+            {
+                fightStats.Add(new Dictionary<string, object?>
+                {
+                    ["character"] = fs.Character.Entry,
+                    ["wins"] = fs.Wins,
+                    ["losses"] = fs.Losses
+                });
+            }
+            if (fightStats.Count > 0)
+                enemy["by_character"] = fightStats;
+            enemies.Add(enemy);
+        }
+        result["enemy_stats"] = enemies;
+
+        var ancients = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.AncientStats)
+        {
+            var anc = new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key.Entry,
+                ["total_visits"] = kv.Value.TotalVisits,
+                ["total_wins"] = kv.Value.TotalWins,
+                ["total_losses"] = kv.Value.TotalLosses
+            };
+            var charStats = new List<Dictionary<string, object?>>();
+            foreach (var cs in kv.Value.CharStats)
+            {
+                charStats.Add(new Dictionary<string, object?>
+                {
+                    ["character"] = cs.Character.Entry,
+                    ["wins"] = cs.Wins,
+                    ["losses"] = cs.Losses
+                });
+            }
+            if (charStats.Count > 0)
+                anc["by_character"] = charStats;
+            ancients.Add(anc);
+        }
+        result["ancient_stats"] = ancients;
+
+        result["discovered_cards"] = progress.DiscoveredCards.Select(id => id.Entry).ToList();
+        result["discovered_relics"] = progress.DiscoveredRelics.Select(id => id.Entry).ToList();
+        result["discovered_potions"] = progress.DiscoveredPotions.Select(id => id.Entry).ToList();
+        result["discovered_events"] = progress.DiscoveredEvents.Select(id => id.Entry).ToList();
+        result["discovered_acts"] = progress.DiscoveredActs.Select(id => id.Entry).ToList();
+
+        var achievements = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.UnlockedAchievements)
+        {
+            achievements.Add(new Dictionary<string, object?>
+            {
+                ["id"] = kv.Key,
+                ["unlocked_at"] = kv.Value
+            });
+        }
+        result["achievements"] = achievements;
+
+        result["epochs"] = progress.Epochs.Select(e => new Dictionary<string, object?>
+        {
+            ["id"] = e.Id,
+            ["state"] = e.State.ToString(),
+            ["obtained"] = e.ObtainDate
+        }).ToList();
+
+        result["total_playtime"] = progress.TotalPlaytime;
+        result["total_unlocks"] = progress.TotalUnlocks;
+        result["current_score"] = progress.CurrentScore;
+        result["floors_climbed"] = progress.FloorsClimbed;
+        result["architect_damage"] = progress.ArchitectDamage;
+        result["total_wins"] = progress.Wins;
+        result["total_losses"] = progress.Losses;
+        result["fastest_victory"] = progress.FastestVictory;
+        result["best_win_streak"] = progress.BestWinStreak;
+        result["number_of_runs"] = progress.NumberOfRuns;
+
+        return result;
+    }
+}

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -245,43 +245,45 @@ public static partial class McpMod
                             result["menu_screen"] = "timeline";
                             result["message"] = "Timeline screen.";
 
-                            // Read epoch slots from the timeline
+                            // Read epoch slots from UI + progress save
                             try
                             {
-                                var slotsContainer = timelineScreen.GetType().GetField("_epochSlotContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen) as Control;
-                                if (slotsContainer == null)
-                                    slotsContainer = timelineScreen.GetType().GetField("_slotsContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen) as Control;
+                                var epochList = new List<Dictionary<string, object?>>();
 
-                                if (slotsContainer != null)
+                                // Get slots from UI for hover tip data
+                                var allSlots = FindAll<NEpochSlot>(timelineScreen);
+                                foreach (var slot in allSlots)
                                 {
-                                    var slots = FindAll<NEpochSlot>(slotsContainer);
-                                    var epochList = new List<Dictionary<string, object?>>();
-                                    foreach (var slot in slots)
+                                    try
                                     {
-                                        try
+                                        var era = slot.GetType().GetField("_era", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
+                                        var hoverTip = slot.GetType().GetField("_hoverTip", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
+                                        var stateVal = slot.State;
+
+                                        var epochData = new Dictionary<string, object?>
                                         {
-                                            var era = slot.GetType().GetField("_era", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
-                                            var hoverTip = slot.GetType().GetField("_hoverTip", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
-                                            var state_val = slot.State;
+                                            ["state"] = stateVal.ToString(),
+                                            ["era"] = era?.ToString(),
+                                        };
 
-                                            var epochData = new Dictionary<string, object?>
-                                            {
-                                                ["state"] = state_val.ToString(),
-                                            };
-
-                                            if (hoverTip is HoverTip ht)
-                                            {
-                                                epochData["name"] = SafeGetText(() => ht.Title);
-                                                epochData["description"] = SafeGetText(() => ht.Description);
-                                            }
-
-                                            epochList.Add(epochData);
+                                        if (hoverTip is HoverTip ht)
+                                        {
+                                            epochData["name"] = SafeGetText(() => ht.Title);
+                                            epochData["description"] = SafeGetText(() => ht.Description);
                                         }
-                                        catch { }
+                                        else if (stateVal.ToString() == "Complete" || stateVal.ToString() == "Obtained")
+                                        {
+                                            // For completed epochs, use era name as fallback
+                                            epochData["name"] = era?.ToString()?.Replace("0", "").Replace("1", "").Replace("2", "").Replace("3", "").Replace("4", "").Replace("5", "").Replace("6", "").Replace("7", "");
+                                        }
+
+                                        epochList.Add(epochData);
                                     }
-                                    if (epochList.Count > 0)
-                                        result["epochs"] = epochList;
+                                    catch { }
                                 }
+
+                                if (epochList.Count > 0)
+                                    result["epochs"] = epochList;
                             }
                             catch { }
                         }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -466,7 +466,7 @@ public static partial class McpMod
         // overlay stack while the map opens after the player clicks proceed.
         var topOverlay = NOverlayStack.Instance?.Peek();
         var currentRoom = runState.CurrentRoom;
-        bool mapIsOpen = NMapScreen.Instance is { IsOpen: true };
+        bool mapIsOpen = IsMapScreenOpenOrVisible();
         if (topOverlay is NCardGridSelectionScreen cardSelectScreen)
         {
             result["state_type"] = "card_select";
@@ -550,7 +550,7 @@ public static partial class McpMod
             {
                 // After combat ends - reward/card overlays are caught by top-level checks above.
                 // Only handle map and the brief transition before rewards appear.
-                if (NMapScreen.Instance is { IsOpen: true })
+                if (IsMapScreenOpenOrVisible())
                 {
                     result["state_type"] = "map";
                     result["map"] = BuildMapState(runState);
@@ -564,7 +564,7 @@ public static partial class McpMod
         }
         else if (currentRoom is EventRoom eventRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMapState(runState);
@@ -587,7 +587,7 @@ public static partial class McpMod
         }
         else if (currentRoom is MerchantRoom merchantRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMapState(runState);
@@ -608,7 +608,7 @@ public static partial class McpMod
         }
         else if (currentRoom is RestSiteRoom restSiteRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMapState(runState);
@@ -621,7 +621,7 @@ public static partial class McpMod
         }
         else if (currentRoom is TreasureRoom treasureRoom)
         {
-            if (NMapScreen.Instance is { IsOpen: true })
+            if (IsMapScreenOpenOrVisible())
             {
                 result["state_type"] = "map";
                 result["map"] = BuildMapState(runState);

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -63,8 +63,28 @@ public static partial class McpMod
                 if (spSubmenu != null && spSubmenu.Visible)
                 {
                     result["menu_screen"] = "singleplayer";
-                    result["message"] = "Singleplayer mode select: Standard, Daily, Custom.";
-                    result["options"] = new List<string> { "standard", "daily", "custom" };
+                    result["message"] = "Select game mode.";
+
+                    var modeOptions = new List<Dictionary<string, object?>>();
+                    var modeFields = new[] { ("_standardButton", "standard"), ("_dailyButton", "daily"), ("_customButton", "custom") };
+                    foreach (var (fieldName, label) in modeFields)
+                    {
+                        try
+                        {
+                            var btn = spSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
+                            if (btn is Control ctrl && ctrl.Visible)
+                            {
+                                var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
+                                modeOptions.Add(new Dictionary<string, object?>
+                                {
+                                    ["name"] = label,
+                                    ["enabled"] = isEnabled ?? true
+                                });
+                            }
+                        }
+                        catch { }
+                    }
+                    result["options"] = modeOptions;
                 }
                 // Check for character select screen
                 else
@@ -73,7 +93,7 @@ public static partial class McpMod
                     if (charSelect != null && charSelect.Visible)
                     {
                         result["menu_screen"] = "character_select";
-                        result["message"] = "Character select screen is active.";
+                        result["message"] = "Select a character.";
 
                         var buttons = FindAll<NCharacterSelectButton>(charSelect);
                         var characters = new List<Dictionary<string, object?>>();
@@ -81,14 +101,67 @@ public static partial class McpMod
                         {
                             try
                             {
-                                var charModel = btn.GetType().GetField("_character", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(btn);
-                                if (charModel is CharacterModel cm)
+                                if (btn.Character is { } cm)
                                 {
-                                    characters.Add(new Dictionary<string, object?>
+                                    var charData = new Dictionary<string, object?>
                                     {
                                         ["name"] = SafeGetText(() => cm.Title),
-                                        ["id"] = cm.Id.Entry
-                                    });
+                                        ["id"] = cm.Id.Entry,
+                                        ["locked"] = btn.IsLocked,
+                                        ["hp"] = cm.StartingHp,
+                                        ["gold"] = cm.StartingGold,
+                                        ["energy"] = cm.MaxEnergy,
+                                        ["description"] = SafeGetText(() => cm.CardsModifierDescription),
+                                    };
+
+                                    // Starting relics
+                                    var startRelics = new List<Dictionary<string, object?>>();
+                                    foreach (var relic in cm.StartingRelics)
+                                    {
+                                        startRelics.Add(new Dictionary<string, object?>
+                                        {
+                                            ["name"] = SafeGetText(() => relic.Title),
+                                            ["description"] = SafeGetText(() => relic.DynamicDescription)
+                                        });
+                                    }
+                                    if (startRelics.Count > 0)
+                                        charData["starting_relics"] = startRelics;
+
+                                    // Starting deck summary
+                                    var deckCards = new List<string>();
+                                    foreach (var card in cm.StartingDeck)
+                                        deckCards.Add(SafeGetText(() => card.Title) ?? "?");
+                                    if (deckCards.Count > 0)
+                                        charData["starting_deck"] = deckCards;
+
+                                    // Known cards count from card pool
+                                    try
+                                    {
+                                        var allCards = cm.CardPool?.AllCards;
+                                        if (allCards != null)
+                                            charData["total_cards"] = System.Linq.Enumerable.Count(allCards);
+                                    }
+                                    catch { }
+
+                                    // Known relics count from relic pool
+                                    try
+                                    {
+                                        var allRelics = cm.RelicPool?.AllRelics;
+                                        if (allRelics != null)
+                                            charData["total_relics"] = System.Linq.Enumerable.Count(allRelics);
+                                    }
+                                    catch { }
+
+                                    // Known potions count from potion pool
+                                    try
+                                    {
+                                        var allPotions = cm.PotionPool?.AllPotions;
+                                        if (allPotions != null)
+                                            charData["total_potions"] = System.Linq.Enumerable.Count(allPotions);
+                                    }
+                                    catch { }
+
+                                    characters.Add(charData);
                                 }
                             }
                             catch { }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -275,6 +275,11 @@ public static partial class McpMod
                         {
                             result["menu_screen"] = "timeline";
                             result["message"] = "Timeline screen.";
+                            result["options"] = new List<Dictionary<string, object?>>
+                            {
+                                new() { ["name"] = "advance", ["enabled"] = true },
+                                new() { ["name"] = "back", ["enabled"] = true }
+                            };
 
                             // Read epochs from ProgressState (stable, not hover-dependent)
                             try

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -196,16 +196,25 @@ public static partial class McpMod
 
                         var buttons = FindAll<NCharacterSelectButton>(charSelect);
                         var characters = new List<Dictionary<string, object?>>();
+                        var options = new List<Dictionary<string, object?>>();
                         foreach (var btn in buttons)
                         {
                             try
                             {
-                                if (btn.Character is { } cm)
+                                if (btn.Character is { } cm && IsNodeVisible(btn))
                                 {
+                                    var characterId = cm.Id.Entry;
+                                    var characterName = SafeGetText(() => cm.Title);
+                                    options.Add(new Dictionary<string, object?>
+                                    {
+                                        ["name"] = characterId,
+                                        ["enabled"] = !btn.IsLocked
+                                    });
+
                                     var charData = new Dictionary<string, object?>
                                     {
-                                        ["name"] = SafeGetText(() => cm.Title),
-                                        ["id"] = cm.Id.Entry,
+                                        ["name"] = characterName,
+                                        ["id"] = characterId,
                                         ["locked"] = btn.IsLocked,
                                         ["hp"] = cm.StartingHp,
                                         ["gold"] = cm.StartingGold,
@@ -267,6 +276,35 @@ public static partial class McpMod
                         }
                         if (characters.Count > 0)
                             result["characters"] = characters;
+
+                        var embarkBtn = GetInstanceFieldValue(charSelect, "_embarkButton");
+                        if (embarkBtn is NClickableControl embarkClickable && IsNodeVisible(embarkClickable))
+                        {
+                            options.Add(new Dictionary<string, object?>
+                            {
+                                ["name"] = "confirm",
+                                ["enabled"] = embarkClickable.IsEnabled
+                            });
+                            options.Add(new Dictionary<string, object?>
+                            {
+                                ["name"] = "embark",
+                                ["enabled"] = embarkClickable.IsEnabled
+                            });
+                        }
+
+                        var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
+                            ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
+                        if (backBtn is NClickableControl backClickable && IsNodeVisible(backClickable))
+                        {
+                            options.Add(new Dictionary<string, object?>
+                            {
+                                ["name"] = "back",
+                                ["enabled"] = backClickable.IsEnabled
+                            });
+                        }
+
+                        if (options.Count > 0)
+                            result["options"] = options;
                     }
                     else
                     {

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -171,120 +171,7 @@ public static partial class McpMod
                     var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
                     if (charSelect != null && IsNodeVisible(charSelect))
                     {
-                        result["menu_screen"] = "character_select";
-                        result["message"] = "Select a character.";
-
-                        var buttons = FindAll<NCharacterSelectButton>(charSelect);
-                        var characters = new List<Dictionary<string, object?>>();
-                        var options = new List<Dictionary<string, object?>>();
-                        foreach (var btn in buttons)
-                        {
-                            try
-                            {
-                                if (btn.Character is { } cm && IsNodeVisible(btn))
-                                {
-                                    var characterId = cm.Id.Entry;
-                                    var characterName = SafeGetText(() => cm.Title);
-                                    options.Add(new Dictionary<string, object?>
-                                    {
-                                        ["name"] = characterId,
-                                        ["enabled"] = !btn.IsLocked
-                                    });
-
-                                    var charData = new Dictionary<string, object?>
-                                    {
-                                        ["name"] = characterName,
-                                        ["id"] = characterId,
-                                        ["locked"] = btn.IsLocked,
-                                        ["hp"] = cm.StartingHp,
-                                        ["gold"] = cm.StartingGold,
-                                        ["energy"] = cm.MaxEnergy,
-                                        ["description"] = SafeGetText(() => cm.CardsModifierDescription),
-                                    };
-
-                                    // Starting relics
-                                    var startRelics = new List<Dictionary<string, object?>>();
-                                    foreach (var relic in cm.StartingRelics)
-                                    {
-                                        startRelics.Add(new Dictionary<string, object?>
-                                        {
-                                            ["name"] = SafeGetText(() => relic.Title),
-                                            ["description"] = SafeGetText(() => relic.DynamicDescription)
-                                        });
-                                    }
-                                    if (startRelics.Count > 0)
-                                        charData["starting_relics"] = startRelics;
-
-                                    // Starting deck summary
-                                    var deckCards = new List<string>();
-                                    foreach (var card in cm.StartingDeck)
-                                        deckCards.Add(SafeGetText(() => card.Title) ?? "?");
-                                    if (deckCards.Count > 0)
-                                        charData["starting_deck"] = deckCards;
-
-                                    // Known cards count from card pool
-                                    try
-                                    {
-                                        var allCards = cm.CardPool?.AllCards;
-                                        if (allCards != null)
-                                            charData["total_cards"] = System.Linq.Enumerable.Count(allCards);
-                                    }
-                                    catch { }
-
-                                    // Known relics count from relic pool
-                                    try
-                                    {
-                                        var allRelics = cm.RelicPool?.AllRelics;
-                                        if (allRelics != null)
-                                            charData["total_relics"] = System.Linq.Enumerable.Count(allRelics);
-                                    }
-                                    catch { }
-
-                                    // Known potions count from potion pool
-                                    try
-                                    {
-                                        var allPotions = cm.PotionPool?.AllPotions;
-                                        if (allPotions != null)
-                                            charData["total_potions"] = System.Linq.Enumerable.Count(allPotions);
-                                    }
-                                    catch { }
-
-                                    characters.Add(charData);
-                                }
-                            }
-                            catch { }
-                        }
-                        if (characters.Count > 0)
-                            result["characters"] = characters;
-
-                        var embarkBtn = GetInstanceFieldValue(charSelect, "_embarkButton");
-                        if (embarkBtn is NClickableControl embarkClickable && IsNodeVisible(embarkClickable))
-                        {
-                            options.Add(new Dictionary<string, object?>
-                            {
-                                ["name"] = "confirm",
-                                ["enabled"] = embarkClickable.IsEnabled
-                            });
-                            options.Add(new Dictionary<string, object?>
-                            {
-                                ["name"] = "embark",
-                                ["enabled"] = embarkClickable.IsEnabled
-                            });
-                        }
-
-                        var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
-                            ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
-                        if (backBtn is NClickableControl backClickable && IsNodeVisible(backClickable))
-                        {
-                            options.Add(new Dictionary<string, object?>
-                            {
-                                ["name"] = "back",
-                                ["enabled"] = backClickable.IsEnabled
-                            });
-                        }
-
-                        if (options.Count > 0)
-                            result["options"] = options;
+                        AddCharacterSelectMenuState(result, charSelect);
                     }
                     else
                     {
@@ -457,6 +344,16 @@ public static partial class McpMod
         var runState = RunManager.Instance.DebugOnlyGetState();
         if (runState == null)
         {
+            if (tree?.Root != null)
+            {
+                var activeCharSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
+                if (activeCharSelect != null && IsNodeVisible(activeCharSelect))
+                {
+                    AddCharacterSelectMenuState(result, activeCharSelect);
+                    return result;
+                }
+            }
+
             result["state_type"] = "unknown";
             return result;
         }
@@ -632,6 +529,19 @@ public static partial class McpMod
                 result["treasure"] = BuildTreasureState(treasureRoom, runState);
             }
         }
+        else if (currentRoom == null && tree?.Root != null)
+        {
+            var activeCharSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
+            if (activeCharSelect != null && IsNodeVisible(activeCharSelect))
+            {
+                AddCharacterSelectMenuState(result, activeCharSelect);
+            }
+            else
+            {
+                result["state_type"] = "unknown";
+                result["room_type"] = currentRoom?.GetType().Name;
+            }
+        }
         else
         {
             result["state_type"] = "unknown";
@@ -654,6 +564,122 @@ public static partial class McpMod
         }
 
         return result;
+    }
+
+    private static void AddCharacterSelectMenuState(
+        Dictionary<string, object?> result,
+        NCharacterSelectScreen charSelect)
+    {
+        result["state_type"] = "menu";
+        result["menu_screen"] = "character_select";
+        result["message"] = "Select a character.";
+
+        var buttons = FindAll<NCharacterSelectButton>(charSelect);
+        var characters = new List<Dictionary<string, object?>>();
+        var options = new List<Dictionary<string, object?>>();
+        foreach (var btn in buttons)
+        {
+            try
+            {
+                if (btn.Character is { } cm && IsNodeVisible(btn))
+                {
+                    var characterId = cm.Id.Entry;
+                    var characterName = SafeGetText(() => cm.Title);
+                    options.Add(new Dictionary<string, object?>
+                    {
+                        ["name"] = characterId,
+                        ["enabled"] = !btn.IsLocked
+                    });
+
+                    var charData = new Dictionary<string, object?>
+                    {
+                        ["name"] = characterName,
+                        ["id"] = characterId,
+                        ["locked"] = btn.IsLocked,
+                        ["hp"] = cm.StartingHp,
+                        ["gold"] = cm.StartingGold,
+                        ["energy"] = cm.MaxEnergy,
+                        ["description"] = SafeGetText(() => cm.CardsModifierDescription),
+                    };
+
+                    var startRelics = new List<Dictionary<string, object?>>();
+                    foreach (var relic in cm.StartingRelics)
+                    {
+                        startRelics.Add(new Dictionary<string, object?>
+                        {
+                            ["name"] = SafeGetText(() => relic.Title),
+                            ["description"] = SafeGetText(() => relic.DynamicDescription)
+                        });
+                    }
+                    if (startRelics.Count > 0)
+                        charData["starting_relics"] = startRelics;
+
+                    var deckCards = new List<string>();
+                    foreach (var card in cm.StartingDeck)
+                        deckCards.Add(SafeGetText(() => card.Title) ?? "?");
+                    if (deckCards.Count > 0)
+                        charData["starting_deck"] = deckCards;
+
+                    try
+                    {
+                        var allCards = cm.CardPool?.AllCards;
+                        if (allCards != null)
+                            charData["total_cards"] = System.Linq.Enumerable.Count(allCards);
+                    }
+                    catch { }
+
+                    try
+                    {
+                        var allRelics = cm.RelicPool?.AllRelics;
+                        if (allRelics != null)
+                            charData["total_relics"] = System.Linq.Enumerable.Count(allRelics);
+                    }
+                    catch { }
+
+                    try
+                    {
+                        var allPotions = cm.PotionPool?.AllPotions;
+                        if (allPotions != null)
+                            charData["total_potions"] = System.Linq.Enumerable.Count(allPotions);
+                    }
+                    catch { }
+
+                    characters.Add(charData);
+                }
+            }
+            catch { }
+        }
+        if (characters.Count > 0)
+            result["characters"] = characters;
+
+        var embarkBtn = GetInstanceFieldValue(charSelect, "_embarkButton");
+        if (embarkBtn is NClickableControl embarkClickable && IsNodeVisible(embarkClickable))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "confirm",
+                ["enabled"] = embarkClickable.IsEnabled
+            });
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "embark",
+                ["enabled"] = embarkClickable.IsEnabled
+            });
+        }
+
+        var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
+            ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
+        if (backBtn is NClickableControl backClickable && IsNodeVisible(backClickable))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "back",
+                ["enabled"] = backClickable.IsEnabled
+            });
+        }
+
+        if (options.Count > 0)
+            result["options"] = options;
     }
 
     private static Dictionary<string, object?> BuildBattleState(RunState runState, CombatRoom combatRoom)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -40,6 +40,8 @@ using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Models.RelicPools;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
+using MegaCrit.Sts2.Core.Nodes.Screens.Settings;
 using Godot;
 
 namespace STS2_MCP;
@@ -86,8 +88,70 @@ public static partial class McpMod
                     }
                     result["options"] = modeOptions;
                 }
-                // Check for character select screen
+                // Check for multiplayer host submenu (Standard / Daily / Custom for multiplayer)
                 else
+                {
+                    var mpHostSubmenu = FindFirst<NMultiplayerHostSubmenu>(tree.Root);
+                    if (mpHostSubmenu != null && mpHostSubmenu.Visible)
+                    {
+                        result["menu_screen"] = "multiplayer_host";
+                        result["message"] = "Multiplayer host: select game mode.";
+
+                        var modeOptions = new List<Dictionary<string, object?>>();
+                        var modeFields = new[] { ("_standardButton", "standard"), ("_dailyButton", "daily"), ("_customButton", "custom") };
+                        foreach (var (fieldName, label) in modeFields)
+                        {
+                            try
+                            {
+                                var btn = mpHostSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mpHostSubmenu);
+                                if (btn is Control ctrl && ctrl.Visible)
+                                {
+                                    var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
+                                    modeOptions.Add(new Dictionary<string, object?>
+                                    {
+                                        ["name"] = label,
+                                        ["enabled"] = isEnabled ?? true
+                                    });
+                                }
+                            }
+                            catch { }
+                        }
+                        result["options"] = modeOptions;
+                    }
+                    else
+                    {
+                        // Check for multiplayer submenu (Host / Join / Load / Abandon)
+                        var mpSubmenu = FindFirst<NMultiplayerSubmenu>(tree.Root);
+                        if (mpSubmenu != null && mpSubmenu.Visible)
+                        {
+                            result["menu_screen"] = "multiplayer";
+                            result["message"] = "Multiplayer menu.";
+
+                            var mpOptions = new List<Dictionary<string, object?>>();
+                            var mpFields = new[] { ("_hostButton", "host"), ("_joinButton", "join"), ("_loadButton", "load"), ("_abandonButton", "abandon") };
+                            foreach (var (fieldName, label) in mpFields)
+                            {
+                                try
+                                {
+                                    var btn = mpSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mpSubmenu);
+                                    if (btn is Control ctrl && ctrl.Visible)
+                                    {
+                                        var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
+                                        mpOptions.Add(new Dictionary<string, object?>
+                                        {
+                                            ["name"] = label,
+                                            ["enabled"] = isEnabled ?? true
+                                        });
+                                    }
+                                }
+                                catch { }
+                            }
+                            result["options"] = mpOptions;
+                        }
+                    }
+                }
+                // Check for character select screen
+                if (result.ContainsKey("menu_screen") == false)
                 {
                     var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
                     if (charSelect != null && charSelect.Visible)
@@ -171,8 +235,70 @@ public static partial class McpMod
                     }
                     else
                     {
-                        result["menu_screen"] = "main";
-                        result["message"] = "Main menu.";
+                        // Check for other screens
+                        var timelineScreen = FindFirst<NTimelineScreen>(tree.Root);
+                        var compendiumSubmenu = FindFirst<NCompendiumSubmenu>(tree.Root);
+                        var settingsScreen = FindFirst<NSettingsScreen>(tree.Root);
+
+                        if (timelineScreen != null && timelineScreen.Visible)
+                        {
+                            result["menu_screen"] = "timeline";
+                            result["message"] = "Timeline screen.";
+
+                            // Read epoch slots from the timeline
+                            try
+                            {
+                                var slotsContainer = timelineScreen.GetType().GetField("_epochSlotContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen) as Control;
+                                if (slotsContainer == null)
+                                    slotsContainer = timelineScreen.GetType().GetField("_slotsContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(timelineScreen) as Control;
+
+                                if (slotsContainer != null)
+                                {
+                                    var slots = FindAll<NEpochSlot>(slotsContainer);
+                                    var epochList = new List<Dictionary<string, object?>>();
+                                    foreach (var slot in slots)
+                                    {
+                                        try
+                                        {
+                                            var era = slot.GetType().GetField("_era", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
+                                            var hoverTip = slot.GetType().GetField("_hoverTip", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
+                                            var state_val = slot.State;
+
+                                            var epochData = new Dictionary<string, object?>
+                                            {
+                                                ["state"] = state_val.ToString(),
+                                            };
+
+                                            if (hoverTip is HoverTip ht)
+                                            {
+                                                epochData["name"] = SafeGetText(() => ht.Title);
+                                                epochData["description"] = SafeGetText(() => ht.Description);
+                                            }
+
+                                            epochList.Add(epochData);
+                                        }
+                                        catch { }
+                                    }
+                                    if (epochList.Count > 0)
+                                        result["epochs"] = epochList;
+                                }
+                            }
+                            catch { }
+                        }
+                        else if (compendiumSubmenu != null && compendiumSubmenu.Visible)
+                        {
+                            result["menu_screen"] = "compendium";
+                            result["message"] = "Compendium screen.";
+                        }
+                        else if (settingsScreen != null && settingsScreen.Visible)
+                        {
+                            result["menu_screen"] = "settings";
+                            result["message"] = "Settings screen.";
+                        }
+                        else
+                        {
+                            result["menu_screen"] = "main";
+                            result["message"] = "Main menu.";
 
                         var mainMenu = FindFirst<NMainMenu>(tree.Root);
                         if (mainMenu != null)
@@ -192,6 +318,7 @@ public static partial class McpMod
                             }
                             if (options.Count > 0)
                                 result["options"] = options;
+                        }
                         }
                     }
                 }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -101,7 +101,7 @@ public static partial class McpMod
                     {
                         try
                         {
-                            var btn = spSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(spSubmenu);
+                            var btn = GetInstanceFieldValue(spSubmenu, fieldName);
                             if (btn is Control ctrl && ctrl.Visible)
                             {
                                 var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
@@ -114,6 +114,7 @@ public static partial class McpMod
                         }
                         catch { }
                     }
+                    AddMenuOptionIfVisible(modeOptions, spSubmenu, "_backButton", "back");
                     result["options"] = modeOptions;
                 }
                 // Check for multiplayer host submenu (Standard / Daily / Custom for multiplayer)
@@ -131,7 +132,7 @@ public static partial class McpMod
                         {
                             try
                             {
-                                var btn = mpHostSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mpHostSubmenu);
+                                var btn = GetInstanceFieldValue(mpHostSubmenu, fieldName);
                                 if (btn is Control ctrl && ctrl.Visible)
                                 {
                                     var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
@@ -144,6 +145,7 @@ public static partial class McpMod
                             }
                             catch { }
                         }
+                        AddMenuOptionIfVisible(modeOptions, mpHostSubmenu, "_backButton", "back");
                         result["options"] = modeOptions;
                     }
                     else
@@ -161,7 +163,7 @@ public static partial class McpMod
                             {
                                 try
                                 {
-                                    var btn = mpSubmenu.GetType().GetField(fieldName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mpSubmenu);
+                                    var btn = GetInstanceFieldValue(mpSubmenu, fieldName);
                                     if (btn is Control ctrl && ctrl.Visible)
                                     {
                                         var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
@@ -174,6 +176,7 @@ public static partial class McpMod
                                 }
                                 catch { }
                             }
+                            AddMenuOptionIfVisible(mpOptions, mpSubmenu, "_backButton", "back");
                             result["options"] = mpOptions;
                         }
                     }
@@ -268,7 +271,7 @@ public static partial class McpMod
                         var compendiumSubmenu = FindFirst<NCompendiumSubmenu>(tree.Root);
                         var settingsScreen = FindFirst<NSettingsScreen>(tree.Root);
 
-                        if (timelineScreen != null && timelineScreen.Visible)
+                        if (timelineScreen != null && IsNodeVisible(timelineScreen))
                         {
                             result["menu_screen"] = "timeline";
                             result["message"] = "Timeline screen.";
@@ -280,31 +283,51 @@ public static partial class McpMod
                                 if (progress != null)
                                 {
                                     var epochList = new List<Dictionary<string, object?>>();
+                                    var revealedCount = 0;
+                                    var obtainedCount = 0;
+                                    var lockedCount = 0;
+                                    var noSlotCount = 0;
                                     foreach (var epoch in progress.Epochs)
                                     {
                                         var eraName = epoch.Id;
+                                        var state = epoch.State.ToString();
                                         // Clean up ID to readable name
                                         var name = System.Text.RegularExpressions.Regex.Replace(eraName, @"(\d+)$", "");
                                         name = System.Text.RegularExpressions.Regex.Replace(name, @"(?<=[a-z])(?=[A-Z])", " ");
+
+                                        switch (epoch.State)
+                                        {
+                                            case EpochState.Revealed:
+                                                revealedCount++;
+                                                break;
+                                            case EpochState.Obtained:
+                                            case EpochState.ObtainedNoSlot:
+                                                obtainedCount++;
+                                                break;
+                                            case EpochState.NotObtained:
+                                                lockedCount++;
+                                                break;
+                                            case EpochState.NoSlot:
+                                                noSlotCount++;
+                                                break;
+                                        }
 
                                         epochList.Add(new Dictionary<string, object?>
                                         {
                                             ["id"] = eraName,
                                             ["name"] = name,
-                                            ["state"] = epoch.State.ToString(),
+                                            ["state"] = state,
                                             ["obtained"] = epoch.ObtainDate
                                         });
                                     }
 
-                                    // Count total slots from UI for hidden count
-                                    var allSlots = FindAll<NEpochSlot>(timelineScreen);
-                                    var completedCount = allSlots.Count(s => s.State.ToString() == "Complete" || s.State.ToString() == "Obtained");
-                                    var lockedVisible = allSlots.Count(s => s.State.ToString() == "NotObtained");
-
                                     result["epochs"] = epochList;
-                                    result["total_slots"] = allSlots.Count;
-                                    result["completed_count"] = completedCount;
-                                    result["locked_count"] = lockedVisible;
+                                    result["total_slots"] = epochList.Count;
+                                    result["completed_count"] = revealedCount;
+                                    result["revealed_count"] = revealedCount;
+                                    result["obtained_unrevealed_count"] = obtainedCount;
+                                    result["locked_count"] = lockedCount;
+                                    result["no_slot_count"] = noSlotCount;
                                 }
                             }
                             catch { }
@@ -410,7 +433,7 @@ public static partial class McpMod
             result["game_over"] = new Dictionary<string, object?>
             {
                 ["message"] = "Run ended.",
-                ["options"] = new List<string> { "continue", "main_menu" }
+                ["options"] = new List<string> { "main_menu" }
             };
         }
         else if (topOverlay is IOverlayScreen

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -64,7 +64,7 @@ public static partial class McpMod
             {
                 // Check for tutorial FTUE popup
                 var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
-                if (tutorialFtue != null && tutorialFtue.Visible)
+                if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
                 {
                     result["menu_screen"] = "tutorial_prompt";
                     result["message"] = "Enable Tutorials? Choose yes or no.";
@@ -79,7 +79,7 @@ public static partial class McpMod
                 if (!result.ContainsKey("menu_screen"))
                 {
                     var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
-                    if (ftue != null && ftue.Visible)
+                    if (ftue != null && IsNodeVisible(ftue))
                     {
                         result["menu_screen"] = "tutorial";
                         result["message"] = "Tutorial popup active. Use advance to dismiss.";
@@ -94,7 +94,7 @@ public static partial class McpMod
                 {
                 // Check for singleplayer submenu (Standard / Daily / Custom)
                 var spSubmenu = FindFirst<NSingleplayerSubmenu>(tree.Root);
-                if (spSubmenu != null && spSubmenu.Visible)
+                if (spSubmenu != null && IsNodeVisible(spSubmenu))
                 {
                     result["menu_screen"] = "singleplayer";
                     result["message"] = "Select game mode.";
@@ -106,7 +106,7 @@ public static partial class McpMod
                         try
                         {
                             var btn = GetInstanceFieldValue(spSubmenu, fieldName);
-                            if (btn is Control ctrl && ctrl.Visible)
+                            if (btn is Control ctrl && IsNodeVisible(ctrl))
                             {
                                 var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
                                 modeOptions.Add(new Dictionary<string, object?>
@@ -125,7 +125,7 @@ public static partial class McpMod
                 else
                 {
                     var mpHostSubmenu = FindFirst<NMultiplayerHostSubmenu>(tree.Root);
-                    if (mpHostSubmenu != null && mpHostSubmenu.Visible)
+                    if (mpHostSubmenu != null && IsNodeVisible(mpHostSubmenu))
                     {
                         result["menu_screen"] = "multiplayer_host";
                         result["message"] = "Multiplayer host: select game mode.";
@@ -137,7 +137,7 @@ public static partial class McpMod
                             try
                             {
                                 var btn = GetInstanceFieldValue(mpHostSubmenu, fieldName);
-                                if (btn is Control ctrl && ctrl.Visible)
+                                if (btn is Control ctrl && IsNodeVisible(ctrl))
                                 {
                                     var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
                                     modeOptions.Add(new Dictionary<string, object?>
@@ -156,7 +156,7 @@ public static partial class McpMod
                     {
                         // Check for multiplayer submenu (Host / Join / Load / Abandon)
                         var mpSubmenu = FindFirst<NMultiplayerSubmenu>(tree.Root);
-                        if (mpSubmenu != null && mpSubmenu.Visible)
+                        if (mpSubmenu != null && IsNodeVisible(mpSubmenu))
                         {
                             result["menu_screen"] = "multiplayer";
                             result["message"] = "Multiplayer menu.";
@@ -168,7 +168,7 @@ public static partial class McpMod
                                 try
                                 {
                                     var btn = GetInstanceFieldValue(mpSubmenu, fieldName);
-                                    if (btn is Control ctrl && ctrl.Visible)
+                                    if (btn is Control ctrl && IsNodeVisible(ctrl))
                                     {
                                         var isEnabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
                                         mpOptions.Add(new Dictionary<string, object?>
@@ -189,7 +189,7 @@ public static partial class McpMod
                 if (result.ContainsKey("menu_screen") == false)
                 {
                     var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
-                    if (charSelect != null && charSelect.Visible)
+                    if (charSelect != null && IsNodeVisible(charSelect))
                     {
                         result["menu_screen"] = "character_select";
                         result["message"] = "Select a character.";
@@ -341,12 +341,12 @@ public static partial class McpMod
                             }
                             catch { }
                         }
-                        else if (compendiumSubmenu != null && compendiumSubmenu.Visible)
+                        else if (compendiumSubmenu != null && IsNodeVisible(compendiumSubmenu))
                         {
                             result["menu_screen"] = "compendium";
                             result["message"] = "Compendium screen.";
                         }
-                        else if (settingsScreen != null && settingsScreen.Visible)
+                        else if (settingsScreen != null && IsNodeVisible(settingsScreen))
                         {
                             result["menu_screen"] = "settings";
                             result["message"] = "Settings screen.";

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Context;
 using MegaCrit.Sts2.Core.Entities.Cards;

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -53,43 +53,22 @@ public static partial class McpMod
     private static Dictionary<string, object?> BuildGameState()
     {
         var result = new Dictionary<string, object?>();
+        var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
+
+        if (tree?.Root != null)
+        {
+            var ftueState = BuildVisibleFtueState(tree.Root);
+            if (ftueState != null)
+                return ftueState;
+        }
 
         if (!RunManager.Instance.IsInProgress)
         {
             result["state_type"] = "menu";
 
             // Detect which menu screen is active
-            var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
             if (tree?.Root != null)
             {
-                // Check for tutorial FTUE popup
-                var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
-                if (tutorialFtue != null && IsNodeVisible(tutorialFtue))
-                {
-                    result["menu_screen"] = "tutorial_prompt";
-                    result["message"] = "Enable Tutorials? Choose yes or no.";
-                    result["options"] = new List<Dictionary<string, object?>>
-                    {
-                        new() { ["name"] = "no", ["enabled"] = true },
-                        new() { ["name"] = "yes", ["enabled"] = true }
-                    };
-                }
-
-                // Check for any other FTUE popup
-                if (!result.ContainsKey("menu_screen"))
-                {
-                    var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
-                    if (ftue != null && IsNodeVisible(ftue))
-                    {
-                        result["menu_screen"] = "tutorial";
-                        result["message"] = "Tutorial popup active. Use advance to dismiss.";
-                        result["options"] = new List<Dictionary<string, object?>>
-                        {
-                            new() { ["name"] = "advance", ["enabled"] = true }
-                        };
-                    }
-                }
-
                 if (!result.ContainsKey("menu_screen"))
                 {
                 // Check for singleplayer submenu (Standard / Daily / Custom)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -245,45 +245,39 @@ public static partial class McpMod
                             result["menu_screen"] = "timeline";
                             result["message"] = "Timeline screen.";
 
-                            // Read epoch slots from UI + progress save
+                            // Read epochs from ProgressState (stable, not hover-dependent)
                             try
                             {
-                                var epochList = new List<Dictionary<string, object?>>();
-
-                                // Get slots from UI for hover tip data
-                                var allSlots = FindAll<NEpochSlot>(timelineScreen);
-                                foreach (var slot in allSlots)
+                                var progress = SaveManager.Instance?.Progress;
+                                if (progress != null)
                                 {
-                                    try
+                                    var epochList = new List<Dictionary<string, object?>>();
+                                    foreach (var epoch in progress.Epochs)
                                     {
-                                        var era = slot.GetType().GetField("_era", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
-                                        var hoverTip = slot.GetType().GetField("_hoverTip", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(slot);
-                                        var stateVal = slot.State;
+                                        var eraName = epoch.Id;
+                                        // Clean up ID to readable name
+                                        var name = System.Text.RegularExpressions.Regex.Replace(eraName, @"(\d+)$", "");
+                                        name = System.Text.RegularExpressions.Regex.Replace(name, @"(?<=[a-z])(?=[A-Z])", " ");
 
-                                        var epochData = new Dictionary<string, object?>
+                                        epochList.Add(new Dictionary<string, object?>
                                         {
-                                            ["state"] = stateVal.ToString(),
-                                            ["era"] = era?.ToString(),
-                                        };
-
-                                        if (hoverTip is HoverTip ht)
-                                        {
-                                            epochData["name"] = SafeGetText(() => ht.Title);
-                                            epochData["description"] = SafeGetText(() => ht.Description);
-                                        }
-                                        else if (stateVal.ToString() == "Complete" || stateVal.ToString() == "Obtained")
-                                        {
-                                            // For completed epochs, use era name as fallback
-                                            epochData["name"] = era?.ToString()?.Replace("0", "").Replace("1", "").Replace("2", "").Replace("3", "").Replace("4", "").Replace("5", "").Replace("6", "").Replace("7", "");
-                                        }
-
-                                        epochList.Add(epochData);
+                                            ["id"] = eraName,
+                                            ["name"] = name,
+                                            ["state"] = epoch.State.ToString(),
+                                            ["obtained"] = epoch.ObtainDate
+                                        });
                                     }
-                                    catch { }
-                                }
 
-                                if (epochList.Count > 0)
+                                    // Count total slots from UI for hidden count
+                                    var allSlots = FindAll<NEpochSlot>(timelineScreen);
+                                    var completedCount = allSlots.Count(s => s.State.ToString() == "Complete" || s.State.ToString() == "Obtained");
+                                    var lockedVisible = allSlots.Count(s => s.State.ToString() == "NotObtained");
+
                                     result["epochs"] = epochList;
+                                    result["total_slots"] = allSlots.Count;
+                                    result["completed_count"] = completedCount;
+                                    result["locked_count"] = lockedVisible;
+                                }
                             }
                             catch { }
                         }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -44,6 +44,7 @@ using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
 using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
 using MegaCrit.Sts2.Core.Nodes.Screens.Settings;
+using MegaCrit.Sts2.Core.Nodes.Screens.ProfileScreen;
 using Godot;
 
 namespace STS2_MCP;
@@ -370,6 +371,49 @@ public static partial class McpMod
                         }
                         else
                         {
+                            var profileScreen = FindFirst<NProfileScreen>(tree.Root);
+                            if (profileScreen != null && IsNodeVisible(profileScreen))
+                            {
+                                result["menu_screen"] = "profile_select";
+                                result["message"] = "Profile select screen.";
+                                result["current_profile_id"] = SaveManager.Instance?.CurrentProfileId;
+
+                                var options = new List<Dictionary<string, object?>>();
+                                var buttons = GetInstanceFieldValue(profileScreen, "_profileButtons") as System.Collections.IEnumerable;
+                                if (buttons != null)
+                                {
+                                    foreach (var btn in buttons)
+                                    {
+                                        var btnId = GetInstanceFieldValue(btn, "_profileId");
+                                        if (btnId is int id)
+                                        {
+                                            var enabled = btn.GetType().GetProperty("IsEnabled")?.GetValue(btn) as bool?;
+                                            options.Add(new Dictionary<string, object?>
+                                            {
+                                                ["name"] = $"profile_{id}",
+                                                ["enabled"] = enabled ?? true
+                                            });
+                                        }
+                                    }
+                                }
+
+                                var backBtn = GetInstanceFieldValue(profileScreen, "_backButton")
+                                    ?? FindFirst<NBackButton>(profileScreen);
+                                if (backBtn is NClickableControl backClickable && IsNodeVisible(backClickable))
+                                {
+                                    options.Add(new Dictionary<string, object?>
+                                    {
+                                        ["name"] = "back",
+                                        ["enabled"] = backClickable.IsEnabled
+                                    });
+                                }
+
+                                if (options.Count > 0)
+                                    result["options"] = options;
+                            }
+                        }
+                        if (!result.ContainsKey("menu_screen"))
+                        {
                             result["menu_screen"] = "main";
                             result["message"] = "Main menu.";
 
@@ -478,6 +522,11 @@ public static partial class McpMod
                 ["screen_type"] = topOverlay.GetType().Name,
                 ["message"] = $"An overlay ({topOverlay.GetType().Name}) is active. It may require manual interaction in-game."
             };
+        }
+        else if (mapIsOpen)
+        {
+            result["state_type"] = "map";
+            result["map"] = BuildMapState(runState);
         }
         else if (currentRoom is CombatRoom combatRoom)
         {

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -308,8 +308,10 @@ public static partial class McpMod
                         if (mainMenu != null)
                         {
                             var options = new List<string>();
+                            var blockedOptions = new List<Dictionary<string, object?>>();
                             var fields = new[] { "_continueButton", "_singleplayerButton", "_multiplayerButton", "_compendiumButton", "_timelineButton", "_settingsButton", "_quitButton" };
                             var labels = new[] { "continue", "singleplayer", "multiplayer", "compendium", "timeline", "settings", "quit" };
+                            var unrevealedEpochs = GetProgressEpochIdsByState("Obtained", "ObtainedNoSlot");
                             for (int i = 0; i < fields.Length; i++)
                             {
                                 try
@@ -320,6 +322,18 @@ public static partial class McpMod
                                         clickable.Visible &&
                                         clickable.IsVisibleInTree())
                                     {
+                                        if (labels[i] == "timeline" && unrevealedEpochs.Count > 0)
+                                        {
+                                            blockedOptions.Add(new Dictionary<string, object?>
+                                            {
+                                                ["name"] = "timeline",
+                                                ["enabled"] = false,
+                                                ["reason"] = "manual_epoch_reveal_required",
+                                                ["pending_epoch_ids"] = unrevealedEpochs
+                                            });
+                                            continue;
+                                        }
+
                                         options.Add(labels[i]);
                                     }
                                 }
@@ -327,6 +341,8 @@ public static partial class McpMod
                             }
                             if (options.Count > 0)
                                 result["options"] = options;
+                            if (blockedOptions.Count > 0)
+                                result["blocked_options"] = blockedOptions;
                         }
                         }
                     }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -37,6 +37,10 @@ using MegaCrit.Sts2.Core.Rewards;
 using MegaCrit.Sts2.Core.Models.Monsters;
 using MegaCrit.Sts2.Core.Rooms;
 using MegaCrit.Sts2.Core.Runs;
+using MegaCrit.Sts2.Core.Models.RelicPools;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using Godot;
 
 namespace STS2_MCP;
 
@@ -49,7 +53,81 @@ public static partial class McpMod
         if (!RunManager.Instance.IsInProgress)
         {
             result["state_type"] = "menu";
-            result["message"] = "No run in progress. Player is in the main menu.";
+
+            // Detect which menu screen is active
+            var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
+            if (tree?.Root != null)
+            {
+                // Check for singleplayer submenu (Standard / Daily / Custom)
+                var spSubmenu = FindFirst<NSingleplayerSubmenu>(tree.Root);
+                if (spSubmenu != null && spSubmenu.Visible)
+                {
+                    result["menu_screen"] = "singleplayer";
+                    result["message"] = "Singleplayer mode select: Standard, Daily, Custom.";
+                    result["options"] = new List<string> { "standard", "daily", "custom" };
+                }
+                // Check for character select screen
+                else
+                {
+                    var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
+                    if (charSelect != null && charSelect.Visible)
+                    {
+                        result["menu_screen"] = "character_select";
+                        result["message"] = "Character select screen is active.";
+
+                        var buttons = FindAll<NCharacterSelectButton>(charSelect);
+                        var characters = new List<Dictionary<string, object?>>();
+                        foreach (var btn in buttons)
+                        {
+                            try
+                            {
+                                var charModel = btn.GetType().GetField("_character", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(btn);
+                                if (charModel is CharacterModel cm)
+                                {
+                                    characters.Add(new Dictionary<string, object?>
+                                    {
+                                        ["name"] = SafeGetText(() => cm.Title),
+                                        ["id"] = cm.Id.Entry
+                                    });
+                                }
+                            }
+                            catch { }
+                        }
+                        if (characters.Count > 0)
+                            result["characters"] = characters;
+                    }
+                    else
+                    {
+                        result["menu_screen"] = "main";
+                        result["message"] = "Main menu.";
+
+                        var mainMenu = FindFirst<NMainMenu>(tree.Root);
+                        if (mainMenu != null)
+                        {
+                            var options = new List<string>();
+                            var fields = new[] { "_continueButton", "_singleplayerButton", "_multiplayerButton", "_compendiumButton", "_timelineButton", "_settingsButton", "_quitButton" };
+                            var labels = new[] { "continue", "singleplayer", "multiplayer", "compendium", "timeline", "settings", "quit" };
+                            for (int i = 0; i < fields.Length; i++)
+                            {
+                                try
+                                {
+                                    var btn = mainMenu.GetType().GetField(fields[i], System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mainMenu) as Control;
+                                    if (btn != null && btn.Visible)
+                                        options.Add(labels[i]);
+                                }
+                                catch { }
+                            }
+                            if (options.Count > 0)
+                                result["options"] = options;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                result["message"] = "No run in progress.";
+            }
+
             return result;
         }
 

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -40,6 +40,7 @@ using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Models.RelicPools;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using Godot;
 
 namespace STS2_MCP;
@@ -251,6 +252,15 @@ public static partial class McpMod
         {
             result["state_type"] = "rewards";
             result["rewards"] = BuildRewardsState(rewardsScreen, runState);
+        }
+        else if (topOverlay is NGameOverScreen gameOverScreen)
+        {
+            result["state_type"] = "game_over";
+            result["game_over"] = new Dictionary<string, object?>
+            {
+                ["message"] = "Run ended.",
+                ["options"] = new List<string> { "continue", "main_menu" }
+            };
         }
         else if (topOverlay is IOverlayScreen
                  && topOverlay is not NRewardsScreen

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -83,6 +83,10 @@ public static partial class McpMod
                     {
                         result["menu_screen"] = "tutorial";
                         result["message"] = "Tutorial popup active. Use advance to dismiss.";
+                        result["options"] = new List<Dictionary<string, object?>>
+                        {
+                            new() { ["name"] = "advance", ["enabled"] = true }
+                        };
                     }
                 }
 
@@ -362,9 +366,14 @@ public static partial class McpMod
                             {
                                 try
                                 {
-                                    var btn = mainMenu.GetType().GetField(fields[i], System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(mainMenu) as Control;
-                                    if (btn != null && btn.Visible)
+                                    var btn = GetInstanceFieldValue(mainMenu, fields[i]);
+                                    if (btn is NClickableControl clickable &&
+                                        clickable.IsEnabled &&
+                                        clickable.Visible &&
+                                        clickable.IsVisibleInTree())
+                                    {
                                         options.Add(labels[i]);
+                                    }
                                 }
                                 catch { }
                             }

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -59,6 +59,32 @@ public static partial class McpMod
             var tree = (Godot.Engine.GetMainLoop()) as SceneTree;
             if (tree?.Root != null)
             {
+                // Check for tutorial FTUE popup
+                var tutorialFtue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NAcceptTutorialsFtue>(tree.Root);
+                if (tutorialFtue != null && tutorialFtue.Visible)
+                {
+                    result["menu_screen"] = "tutorial_prompt";
+                    result["message"] = "Enable Tutorials? Choose yes or no.";
+                    result["options"] = new List<Dictionary<string, object?>>
+                    {
+                        new() { ["name"] = "no", ["enabled"] = true },
+                        new() { ["name"] = "yes", ["enabled"] = true }
+                    };
+                }
+
+                // Check for any other FTUE popup
+                if (!result.ContainsKey("menu_screen"))
+                {
+                    var ftue = FindFirst<MegaCrit.Sts2.Core.Nodes.Ftue.NFtue>(tree.Root);
+                    if (ftue != null && ftue.Visible)
+                    {
+                        result["menu_screen"] = "tutorial";
+                        result["message"] = "Tutorial popup active. Use advance to dismiss.";
+                    }
+                }
+
+                if (!result.ContainsKey("menu_screen"))
+                {
                 // Check for singleplayer submenu (Standard / Daily / Custom)
                 var spSubmenu = FindFirst<NSingleplayerSubmenu>(tree.Root);
                 if (spSubmenu != null && spSubmenu.Visible)
@@ -197,6 +223,7 @@ public static partial class McpMod
                     }
                 }
             }
+            } // close if (!result.ContainsKey("menu_screen"))
             else
             {
                 result["message"] = "No run in progress.";

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -119,8 +119,8 @@ public static partial class McpMod
         }
         catch (Exception ex)
         {
-            GD.PrintErr(
-                $"[STS2 MCP] Harmony patches unavailable; continuing without optional UI injection: {ex}");
+            GD.Print(
+                $"[STS2 MCP] Optional Harmony settings UI injection skipped: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -45,11 +45,17 @@ public static partial class McpMod
             string configPath = Path.Combine(modDir, ConfigFileName);
             if (!File.Exists(configPath))
             {
-                // Create default config so the user knows it's configurable
-                var defaultConfig = new Dictionary<string, object> { ["port"] = DefaultPort };
-                string json = JsonSerializer.Serialize(defaultConfig, _jsonOptions);
-                File.WriteAllText(configPath, json);
-                GD.Print($"[STS2 MCP] Created default config at {configPath}");
+                try
+                {
+                    var defaultConfig = new Dictionary<string, object> { ["port"] = DefaultPort };
+                    string json = JsonSerializer.Serialize(defaultConfig, _jsonOptions);
+                    File.WriteAllText(configPath, json);
+                    GD.Print($"[STS2 MCP] Created default config at {configPath}");
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+                {
+                    GD.Print($"[STS2 MCP] No config found at {configPath}; using default port {DefaultPort}");
+                }
                 return DefaultPort;
             }
 
@@ -221,6 +227,22 @@ public static partial class McpMod
                     HandleGetMultiplayerState(request, response);
                 else if (request.HttpMethod == "POST")
                     HandlePostMultiplayerAction(request, response);
+                else
+                    SendError(response, 405, "Method not allowed");
+            }
+            else if (path == "/api/v1/profiles")
+            {
+                if (request.HttpMethod == "GET")
+                    HandleGetProfiles(response);
+                else if (request.HttpMethod == "POST")
+                    HandlePostProfiles(request, response);
+                else
+                    SendError(response, 405, "Method not allowed");
+            }
+            else if (path == "/api/v1/profile")
+            {
+                if (request.HttpMethod == "GET")
+                    HandleGetProfile(response);
                 else
                     SendError(response, 405, "Method not allowed");
             }

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -399,7 +399,8 @@ public static partial class McpMod
             try
             {
                 var option = parsed.TryGetValue("option", out var optElem) ? optElem.GetString() ?? "" : "";
-                var resultTask = RunOnMainThread(() => ExecuteMenuSelect(option));
+                var seed = parsed.TryGetValue("seed", out var seedElem) ? seedElem.GetString() : null;
+                var resultTask = RunOnMainThread(() => ExecuteMenuSelect(option, seed));
                 var result = resultTask.GetAwaiter().GetResult();
                 SendJson(response, result);
             }

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -393,6 +393,23 @@ public static partial class McpMod
 
         string action = actionElem.GetString() ?? "";
 
+        // Handle menu actions separately (no run required)
+        if (action == "menu_select")
+        {
+            try
+            {
+                var option = parsed.TryGetValue("option", out var optElem) ? optElem.GetString() ?? "" : "";
+                var resultTask = RunOnMainThread(() => ExecuteMenuSelect(option));
+                var result = resultTask.GetAwaiter().GetResult();
+                SendJson(response, result);
+            }
+            catch (Exception ex)
+            {
+                SendError(response, 500, $"Menu action failed: {ex.Message}");
+            }
+            return;
+        }
+
         try
         {
             var resultTask = RunOnMainThread(() => ExecuteAction(action, parsed));

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -188,6 +188,7 @@ No run in progress.
 ```
 
 Use `menu_select` with one of the advertised options. Options are accepted case-insensitively.
+If a visible option is intentionally withheld from automation, the state may also include `blocked_options` with a reason. For example, Timeline can be blocked while obtained epochs still need manual reveal because opening that game state through automation can trigger invalid unlock-state errors.
 
 Menu sub-screens expose their own options:
 
@@ -831,6 +832,7 @@ Select an option from the main menu, a menu submenu, profile select, character s
 | `seed` | string | No | Only supported in menu contexts that expose a real seeded flow. Standard singleplayer character select currently returns an error without starting a run when `seed` is supplied. |
 
 `game_over` advertises only `main_menu`. `continue` is not actionable on that screen and returns an error.
+If `timeline` is blocked by pending obtained epochs, `menu_select` returns an error with `manual_action_required: true` and `pending_epoch_ids` instead of opening Timeline.
 
 ---
 

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -178,9 +178,22 @@ No run in progress.
 ```jsonc
 {
   "state_type": "menu",
-  "message": "No run in progress. Player is in the main menu."
+  "message": "No run in progress. Player is in the main menu.",
+  "menu_screen": "main",
+  "options": ["continue", "singleplayer", "multiplayer", "compendium", "timeline", "settings", "quit"]
 }
 ```
+
+Use `menu_select` with one of the advertised options. Options are accepted case-insensitively.
+
+Menu sub-screens expose their own options:
+
+- `singleplayer`: `standard`, `daily`, `custom`, `back`
+- `multiplayer`: `host`, `join`, `load`, `abandon`, `back`
+- `multiplayer_host`: `standard`, `daily`, `custom`, `back`
+- `character_select`: character IDs/names, `back`, `confirm`, `embark`
+- `tutorial_prompt`: `no`, `yes`
+- `timeline`: `advance`, `back`
 
 ### `unknown`
 
@@ -695,6 +708,24 @@ Boss relic selection. Pick is immediate.
 }
 ```
 
+### `game_over`
+
+Run has ended.
+
+```jsonc
+{
+  "state_type": "game_over",
+  "game_over": {
+    "message": "Run ended.",
+    "options": ["main_menu"]
+  },
+  "run": { ... },
+  "player": { ... }
+}
+```
+
+Use `menu_select` with `main_menu` to return to the main menu. `continue` is not advertised because it is not an actionable game-over option.
+
 ### `overlay` — Unhandled Overlay (catch-all)
 
 Prevents soft-locks when an unrecognized overlay is active.
@@ -728,6 +759,27 @@ All POST requests use a JSON body with an `"action"` field and action-specific p
 ```jsonc
 { "status": "error", "error": "Card requires a target. Provide 'target' with an entity_id." }
 ```
+
+---
+
+### `menu_select`
+
+Select an option from the main menu, a menu submenu, character select, tutorial prompt, timeline screen, or game-over screen.
+
+```json
+{ "action": "menu_select", "option": "singleplayer" }
+```
+
+```json
+{ "action": "menu_select", "option": "main_menu" }
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `option` | string | Yes | One of the current state's advertised menu options. Matching is case-insensitive. |
+| `seed` | string | No | Only supported in menu contexts that expose a real seeded flow. Standard singleplayer character select currently returns an error without starting a run when `seed` is supplied. |
+
+`game_over` advertises only `main_menu`. `continue` is not actionable on that screen and returns an error.
 
 ---
 

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -7,6 +7,9 @@ HTTP API served by the STS2_MCP mod on `localhost:15526`. No authentication. Loc
 - `POST /api/v1/singleplayer` — perform a game action
 - `GET  /api/v1/multiplayer` — read multiplayer game state
 - `POST /api/v1/multiplayer` — perform a multiplayer action
+- `GET  /api/v1/profile` — read current profile progress
+- `GET  /api/v1/profiles` — list profile slots
+- `POST /api/v1/profiles` — switch or delete profile slots
 
 The endpoints are mutually exclusive: calling singleplayer during a multiplayer run (or vice versa) returns HTTP 409.
 
@@ -191,6 +194,7 @@ Menu sub-screens expose their own options:
 - `singleplayer`: `standard`, `daily`, `custom`, `back`
 - `multiplayer`: `host`, `join`, `load`, `abandon`, `back`
 - `multiplayer_host`: `standard`, `daily`, `custom`, `back`
+- `profile_select`: `profile_1`, `profile_2`, `profile_3`, `back`
 - `character_select`: character IDs/names, `back`, `confirm`, `embark`
 - `tutorial_prompt`: `no`, `yes`
 - `timeline`: `advance`, `back`
@@ -744,6 +748,52 @@ Prevents soft-locks when an unrecognized overlay is active.
 
 ---
 
+## Profiles
+
+Profile endpoints are independent of the singleplayer and multiplayer run endpoints.
+
+### `GET /api/v1/profile`
+
+Returns the active profile's persistent progress summary, including character stats, card stats, encounter stats, discovered content, achievements, epochs, and global totals.
+
+### `GET /api/v1/profiles`
+
+Lists the three profile slots and identifies the active slot.
+
+```json
+{
+  "current_profile_id": 1,
+  "profiles": [
+    { "id": 1, "is_current": true, "has_data": true },
+    { "id": 2, "is_current": false, "has_data": false },
+    { "id": 3, "is_current": false, "has_data": true }
+  ]
+}
+```
+
+### `POST /api/v1/profiles`
+
+Switch to a profile slot through the game's profile UI:
+
+```json
+{ "action": "switch", "profile_id": 2 }
+```
+
+Delete an inactive profile slot:
+
+```json
+{ "action": "delete", "profile_id": 2 }
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `action` | string | Yes | `switch` or `delete` |
+| `profile_id` | int | Yes | Profile slot, from 1 to 3 |
+
+Switching is rejected during a run. Deleting the active profile is rejected; switch away first if you need to remove a slot.
+
+---
+
 ## POST — Perform Actions
 
 All POST requests use a JSON body with an `"action"` field and action-specific parameters.
@@ -764,7 +814,7 @@ All POST requests use a JSON body with an `"action"` field and action-specific p
 
 ### `menu_select`
 
-Select an option from the main menu, a menu submenu, character select, tutorial prompt, timeline screen, or game-over screen.
+Select an option from the main menu, a menu submenu, profile select, character select, tutorial prompt, timeline screen, or game-over screen.
 
 ```json
 { "action": "menu_select", "option": "singleplayer" }

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -197,6 +197,7 @@ Menu sub-screens expose their own options:
 - `profile_select`: `profile_1`, `profile_2`, `profile_3`, `back`
 - `character_select`: character IDs/names, `back`, `confirm`, `embark`
 - `tutorial_prompt`: `no`, `yes`
+- `popup`: advertised popup button labels, normalized to lowercase words such as `ignore` or `back`
 - `timeline`: `advance`, `back`
 
 ### `unknown`
@@ -814,7 +815,7 @@ All POST requests use a JSON body with an `"action"` field and action-specific p
 
 ### `menu_select`
 
-Select an option from the main menu, a menu submenu, profile select, character select, tutorial prompt, timeline screen, or game-over screen.
+Select an option from the main menu, a menu submenu, profile select, character select, tutorial prompt, blocking popup, timeline screen, or game-over screen.
 
 ```json
 { "action": "menu_select", "option": "singleplayer" }

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -6,6 +6,9 @@ HTTP API on `localhost:15526`. No authentication.
 - `POST /api/v1/singleplayer` — perform action
 - `GET /api/v1/multiplayer` — read multiplayer state
 - `POST /api/v1/multiplayer` — perform multiplayer action
+- `GET /api/v1/profile` — read current profile progress
+- `GET /api/v1/profiles` — list profile slots
+- `POST /api/v1/profiles` — switch or delete profile slots
 
 Singleplayer and multiplayer endpoints are mutually exclusive (HTTP 409 if mismatched).
 
@@ -53,7 +56,31 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 | Action | Parameters | When to Use |
 |---|---|---|
-| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
+| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
+
+### Profiles
+
+`GET /api/v1/profile` returns persistent progress for the active profile, including character stats, discoveries, achievements, epochs, and global run totals.
+
+`GET /api/v1/profiles` returns the three profile slots:
+
+```json
+{
+  "current_profile_id": 1,
+  "profiles": [
+    { "id": 1, "is_current": true, "has_data": true },
+    { "id": 2, "is_current": false, "has_data": false },
+    { "id": 3, "is_current": false, "has_data": true }
+  ]
+}
+```
+
+`POST /api/v1/profiles` supports:
+
+| Action | Parameters | When to Use |
+|---|---|---|
+| `switch` | `profile_id`: 1-3 | Switch through the game profile UI. Empty slots can be used for fresh-profile testing. Cannot be used during a run. |
+| `delete` | `profile_id`: 1-3 | Delete an inactive profile slot. The active profile is rejected. |
 
 ### Combat
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -24,7 +24,7 @@ Every JSON response includes:
 
 | `state_type` | Screen | Available Actions |
 |---|---|---|
-| `menu` | Main menu, no run in progress | None |
+| `menu` | Main menu or menu submenu, no run in progress | `menu_select` |
 | `unknown` | Unrecognized room or null state | None |
 | `monster` / `elite` / `boss` | In combat | `play_card`, `use_potion`, `end_turn` |
 | `hand_select` | In-combat card selection (exhaust, discard, upgrade) | `combat_select_card`, `combat_confirm_selection` |
@@ -40,6 +40,7 @@ Every JSON response includes:
 | `bundle_select` | Card bundle choice overlay | `select_bundle`, `confirm_bundle_selection`, `cancel_bundle_selection` |
 | `relic_select` | Relic choice overlay (boss relics) | `select_relic`, `skip_relic_selection` |
 | `crystal_sphere` | Crystal Sphere minigame | `crystal_sphere_set_tool`, `crystal_sphere_click_cell`, `crystal_sphere_proceed` |
+| `game_over` | Run ended | `menu_select` with `main_menu` |
 | `overlay` | Unhandled overlay (catch-all, prevents soft-lock) | None (manual interaction needed) |
 
 **Note:** `use_potion` and `discard_potion` work during any state where potions are accessible (combat, map, events, etc.).
@@ -47,6 +48,12 @@ Every JSON response includes:
 ## POST — Actions
 
 All POST requests use JSON body with `"action"` field. All responses include `{ "status": "ok" | "error", "message": "..." }`.
+
+### Menu / Game Over
+
+| Action | Parameters | When to Use |
+|---|---|---|
+| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
 
 ### Combat
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -56,7 +56,7 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 | Action | Parameters | When to Use |
 |---|---|---|
-| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. Blocking popups expose normalized button labels such as `ignore` or `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
+| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. Blocking popups expose normalized button labels such as `ignore` or `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. If Timeline has pending obtained epochs that require manual reveal, it may appear in `blocked_options`; selecting `timeline` returns `manual_action_required: true` with `pending_epoch_ids` instead of opening Timeline. |
 
 ### Profiles
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -56,7 +56,7 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 | Action | Parameters | When to Use |
 |---|---|---|
-| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
+| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. Blocking popups expose normalized button labels such as `ignore` or `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. |
 
 ### Profiles
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -5,6 +5,7 @@
 | Tool | Scope | Description |
 |---|---|---|
 | `get_game_state(format?)` | General | Get current game state (`markdown` or `json`) |
+| `menu_select(option, seed?)` | General | Select a visible menu/game-over option |
 | `use_potion(slot, target?)` | General | Use a potion (works in and out of combat) |
 | `discard_potion(slot)` | General | Discard a potion to free up the slot |
 | `proceed_to_map()` | General | Proceed from rewards/rest site/shop/treasure to the map |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,6 +6,10 @@
 |---|---|---|
 | `get_game_state(format?)` | General | Get current game state (`markdown` or `json`) |
 | `menu_select(option, seed?)` | General | Select a visible menu/game-over option |
+| `get_profile()` | Profiles | Get active profile progress |
+| `list_profiles()` | Profiles | List profile slots and active slot |
+| `switch_profile(profile_id)` | Profiles | Switch to a profile slot through the game UI |
+| `delete_profile(profile_id)` | Profiles | Delete an inactive profile slot |
 | `use_potion(slot, target?)` | General | Use a potion (works in and out of combat) |
 | `discard_potion(slot)` | General | Discard a potion to free up the slot |
 | `proceed_to_map()` | General | Proceed from rewards/rest site/shop/treasure to the map |

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -84,10 +84,12 @@ async def _profiles_post(body: dict) -> str:
 
 
 async def _wait_for_profile(profile_id: int, fallback: str) -> str:
+    last_profiles: dict | None = None
     for _ in range(30):
         await asyncio.sleep(0.1)
         profiles_text = await _profiles_get()
         profiles = json.loads(profiles_text)
+        last_profiles = profiles
         if profiles.get("current_profile_id") == profile_id:
             return json.dumps(
                 {
@@ -98,7 +100,25 @@ async def _wait_for_profile(profile_id: int, fallback: str) -> str:
                 },
                 indent=2,
             )
-    return fallback
+
+    return json.dumps(
+        {
+            "status": "error",
+            "error": f"Timed out waiting for profile {profile_id} to become active",
+            "current_profile_id": (
+                last_profiles.get("current_profile_id")
+                if isinstance(last_profiles, dict)
+                else None
+            ),
+            "profiles": (
+                last_profiles.get("profiles", [])
+                if isinstance(last_profiles, dict)
+                else []
+            ),
+            "initial_response": fallback,
+        },
+        indent=2,
+    )
 
 
 def _handle_error(e: Exception) -> str:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -192,6 +192,9 @@ async def switch_profile(profile_id: int) -> str:
         result = await _profiles_post(body)
         try:
             parsed = json.loads(result)
+            if parsed.get("status") == "error":
+                return result
+
             message = parsed.get("message", "")
             if isinstance(message, str) and message.startswith("Opened profile screen"):
                 for _ in range(20):
@@ -200,6 +203,9 @@ async def switch_profile(profile_id: int) -> str:
                     state = json.loads(state_text)
                     if state.get("menu_screen") == "profile_select":
                         result = await _profiles_post(body)
+                        parsed = json.loads(result)
+                        if parsed.get("status") == "error":
+                            return result
                         break
             result = await _wait_for_profile(profile_id, result)
         except json.JSONDecodeError:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -5,6 +5,7 @@ as MCP tools for Claude Desktop / Claude Code.
 """
 
 import argparse
+import asyncio
 import json
 import sys
 
@@ -23,6 +24,14 @@ def _sp_url() -> str:
 
 def _mp_url() -> str:
     return f"{_base_url}/api/v1/multiplayer"
+
+
+def _profile_url() -> str:
+    return f"{_base_url}/api/v1/profile"
+
+
+def _profiles_url() -> str:
+    return f"{_base_url}/api/v1/profiles"
 
 
 async def _get(params: dict | None = None) -> str:
@@ -51,6 +60,45 @@ async def _mp_post(body: dict) -> str:
         r = await client.post(_mp_url(), json=body)
         r.raise_for_status()
         return r.text
+
+
+async def _profile_get() -> str:
+    async with httpx.AsyncClient(timeout=10, trust_env=_trust_env) as client:
+        r = await client.get(_profile_url())
+        r.raise_for_status()
+        return r.text
+
+
+async def _profiles_get() -> str:
+    async with httpx.AsyncClient(timeout=10, trust_env=_trust_env) as client:
+        r = await client.get(_profiles_url())
+        r.raise_for_status()
+        return r.text
+
+
+async def _profiles_post(body: dict) -> str:
+    async with httpx.AsyncClient(timeout=10, trust_env=_trust_env) as client:
+        r = await client.post(_profiles_url(), json=body)
+        r.raise_for_status()
+        return r.text
+
+
+async def _wait_for_profile(profile_id: int, fallback: str) -> str:
+    for _ in range(30):
+        await asyncio.sleep(0.1)
+        profiles_text = await _profiles_get()
+        profiles = json.loads(profiles_text)
+        if profiles.get("current_profile_id") == profile_id:
+            return json.dumps(
+                {
+                    "status": "ok",
+                    "message": f"Switched to profile {profile_id}",
+                    "current_profile_id": profile_id,
+                    "profiles": profiles.get("profiles", []),
+                },
+                indent=2,
+            )
+    return fallback
 
 
 def _handle_error(e: Exception) -> str:
@@ -100,6 +148,79 @@ async def menu_select(option: str, seed: str | None = None) -> str:
         body["seed"] = seed
     try:
         return await _post(body)
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def get_profile() -> str:
+    """Get the current profile's persistent progress summary.
+
+    Includes character stats, discovered content, achievements, epochs, and global
+    run totals for the active profile.
+    """
+    try:
+        return await _profile_get()
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def list_profiles() -> str:
+    """List the three profile slots and identify the active slot.
+
+    The has_data field indicates whether a slot currently has progress data.
+    """
+    try:
+        return await _profiles_get()
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def switch_profile(profile_id: int) -> str:
+    """Switch to a profile slot through the game's profile UI.
+
+    Use an empty slot to create or enter a fresh profile for testing. This cannot
+    be used while a run is in progress.
+
+    Args:
+        profile_id: Profile slot to switch to. Must be 1, 2, or 3.
+    """
+    try:
+        body = {"action": "switch", "profile_id": profile_id}
+        result = await _profiles_post(body)
+        try:
+            parsed = json.loads(result)
+            message = parsed.get("message", "")
+            if isinstance(message, str) and message.startswith("Opened profile screen"):
+                for _ in range(20):
+                    await asyncio.sleep(0.1)
+                    state_text = await _get({"format": "json"})
+                    state = json.loads(state_text)
+                    if state.get("menu_screen") == "profile_select":
+                        result = await _profiles_post(body)
+                        break
+            result = await _wait_for_profile(profile_id, result)
+        except json.JSONDecodeError:
+            pass
+        return result
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def delete_profile(profile_id: int) -> str:
+    """Delete an inactive profile slot.
+
+    The active profile cannot be deleted through this tool. Switch away first if
+    you intend to remove a slot after backing up any data you need.
+
+    Args:
+        profile_id: Profile slot to delete. Must be 1, 2, or 3.
+    """
+    try:
+        return await _profiles_post({"action": "delete", "profile_id": profile_id})
     except Exception as e:
         return _handle_error(e)
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -84,6 +84,27 @@ async def get_game_state(format: str = "markdown") -> str:
 
 
 @mcp.tool()
+async def menu_select(option: str, seed: str | None = None) -> str:
+    """Select a visible menu option.
+
+    Use with state_type "menu" or "game_over". Supports main-menu navigation,
+    singleplayer and multiplayer submenus, character select, timeline controls,
+    tutorial prompts, and game-over main-menu return.
+
+    Args:
+        option: Option ID from the current menu state's options list.
+        seed: Optional seed for supported embark flows. Standard mode rejects seeds.
+    """
+    body: dict = {"action": "menu_select", "option": option}
+    if seed is not None:
+        body["seed"] = seed
+    try:
+        return await _post(body)
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
 async def use_potion(slot: int, target: str | None = None) -> str:
     """Use a potion from the player's potion slots.
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -160,7 +160,9 @@ async def menu_select(option: str, seed: str | None = None) -> str:
     tutorial prompts, and game-over main-menu return.
 
     Args:
-        option: Option ID from the current menu state's options list.
+        option: Option ID from the current menu state's options list. If an
+            option is listed under blocked_options, selecting it returns the
+            API's manual-action response instead of forcing UI entry.
         seed: Optional seed for supported embark flows. Standard mode rejects seeds.
     """
     body: dict = {"action": "menu_select", "option": option}


### PR DESCRIPTION
## Summary

Integrates the tested MCP automation work for menu navigation, run start, profile management, game-over handling, FTUE/popup handling, seeded embark behavior, and timeline safety.

Source branch: `CompleteTech-LLC-AI-Research:ctai/mcp-menu-ftue-timeline-integration`.

## Related Issues

Resolved by this PR, based on direct live validation:

- Resolves #45
- Resolves #66
- Resolves #67
- Resolves #68
- Resolves #70

Partially addressed, but should remain open for more fresh-profile FTUE validation:

- References #69

## Included Behavior

- Detect and format actionable menu states, including markdown output for menu options and character IDs.
- Support `menu_select` for main menu, singleplayer/character-select flows, multiplayer submenu, multiplayer host flow, profile select, timeline, tutorial prompts, blocking popups, and game-over.
- Provide an API path to start a singleplayer standard run from the menu via `menu_select`.
- Add profile APIs and MCP tools: `GET /api/v1/profile`, `GET /api/v1/profiles`, `POST /api/v1/profiles`, plus `get_profile`, `list_profiles`, `switch_profile`, and `delete_profile`.
- Make game-over options consistent: `main_menu` only; `continue` returns a clear non-actionable error.
- Make standard seeded embark non-mutating when the game rejects seed changes.
- Surface visible FTUE/tutorial and blocking modal/popup prompts before normal run states, including active modal-container prompts.
- Resolve multi-page FTUE/tutorial advance controls, including arrow-style controls that are not `_confirmButton` fields.
- Harden timeline advancement so automation does not force-reveal obtained epochs or walk disposed timeline nodes.
- Count timeline epochs from stable progress state rather than live UI slots.
- Return explicit profile-switch timeout errors instead of preserving an earlier successful switch payload.
- Guard reflected menu/back/popup clicks with visibility/actionability checks before `ForceClick`.
- Guard popup button actionability against disposed Godot controls during modal teardown.

## Validation

Live-tested on 2026-04-19 against the running STS2 VM using `remote.ps1` and `sts_qga.py`.

Passed:

- `dotnet build .\STS2_MCP.csproj -c Release -o .\out\STS2_MCP_project`
- `python -m py_compile .\mcp\server.py`
- `git diff --check`
- Main menu JSON and markdown state output.
- Singleplayer submenu navigation, character select, Ironclad selection, and standard run start.
- Multiplayer submenu host/join/back routing.
- Game-over `main_menu` handling and non-actionable `continue` rejection.
- Standard seeded embark rejection without starting an unseeded run.
- Profile listing/switch/delete behavior used for fresh-profile testing.
- Timeline entry, tutorial proceed handling, safe `advance`, and back navigation after post-death unlock.
- Targeted log scan after timeline validation found no new `ObjectDisposedException`, no epoch `invalid state`, no duplicate mod load, and no MCP runtime exception.


Post-error-diagnosis validation for head commit `7347f0f`:

- Build passed: `dotnet build .\STS2_MCP.csproj -c Release -o .\out\STS2_MCP_project`.
- Python MCP syntax passed: `python -m py_compile .\mcp\server.py`.
- Whitespace check passed with only the repo's existing LF-to-CRLF working-copy warnings.
- Rebuilt DLL/PDB deployed to the guest; deployed DLL hash: `35f877ba19754d407ecbaf88ff225612132f5b913c27124c4f3924e19bf6c3a7`.
- Runtime verification of the new Timeline entry guard requires a game restart because the current game process had already loaded the previous assembly.

FTUE status:

- Initial first-run prompt and malformed option rejection were tested.
- Multi-page combat tutorial, reward/card/potion tutorial prompts, event, shop, rest-site tutorial, and timeline tutorial were exercised during CompleteTech live validation.
- FTUE should still remain tracked in #69 because fresh-profile tutorial surfaces are stateful, not all prompts appear reliably on every route/profile, and this deserves broader repeated coverage before closing.

## Notes

- When profile progress contains obtained-but-unrevealed epochs, MCP now blocks main-menu Timeline entry, reports Timeline under `blocked_options`, and returns `manual_action_required: true` with `pending_epoch_ids` instead of entering the game's invalid unlock path.
- Optional Harmony settings UI injection failures are now logged as a concise non-error informational line.
- CompleteTech validation PR: https://github.com/CompleteTech-LLC-AI-Research/STS2MCP/pull/11


