### PR TITLE
Fix combat play phase on STS2 v0.104

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -85,7 +85,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsCombatPlayPhase(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -140,7 +140,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsCombatPlayPhase(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled (turn may already be ending)");
@@ -183,7 +183,7 @@ public static partial class McpMod
         {
             if (!inCombat)
                 return Error($"Potion '{SafeGetText(() => potion.Title)}' can only be used in combat");
-            if (!CombatManager.Instance.IsPlayPhase)
+            if (!IsCombatPlayPhase(player))
                 return Error("Cannot use potions outside of play phase");
         }
         else if (potion.Usage == PotionUsage.Automatic)
@@ -1030,7 +1030,7 @@ public static partial class McpMod
         };
     }
 
-    private static Creature? ResolveTarget(CombatState combatState, string entityId)
+    private static Creature? ResolveTarget(ICombatState combatState, string entityId)
     {
         // Try to match by entity_id pattern: "model_entry_N"
         // First try matching by combat_id if it's a pure number

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -4,7 +4,9 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Godot;
+using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Models;
 
@@ -12,6 +14,29 @@ namespace STS2_MCP;
 
 public static partial class McpMod
 {
+    // STS2 v0.104.0 removed CombatManager.IsPlayPhase. Reconstruct the same
+    // action-safe window from the current combat side and turn-ending flags.
+    private static bool IsCombatPlayPhase(Player? player = null)
+    {
+        try
+        {
+            var combatState = CombatManager.Instance.DebugOnlyGetState();
+            bool playerTurn = player != null
+                ? CombatManager.Instance.IsPartOfPlayerTurn(player)
+                : combatState?.CurrentSide.ToString().Equals("Player", StringComparison.OrdinalIgnoreCase) == true;
+
+            return CombatManager.Instance.IsInProgress
+                && playerTurn
+                && !CombatManager.Instance.EndingPlayerTurnPhaseOne
+                && !CombatManager.Instance.EndingPlayerTurnPhaseTwo
+                && !CombatManager.Instance.PlayerActionsDisabled;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static string? SafeGetCardDescription(CardModel card, PileType pile = PileType.Hand)
     {
         try { return StripRichTextTags(card.GetDescriptionForPile(pile)).Replace("\n", " "); }

--- a/McpMod.MultiplayerActions.cs
+++ b/McpMod.MultiplayerActions.cs
@@ -68,7 +68,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsCombatPlayPhase(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -101,7 +101,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsCombatPlayPhase(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");

--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -256,7 +256,7 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        battle["is_play_phase"] = IsCombatPlayPhase();
         battle["all_players_ready"] = CombatManager.Instance.AllPlayersReadyToEndTurn();
 
         // Enemies

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -254,7 +254,7 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        battle["is_play_phase"] = IsCombatPlayPhase();
 
         // Enemies
         var enemies = new List<Dictionary<string, object?>>();

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A mod for [**Slay the Spire 2**](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/) that lets AI agents play the game. Exposes game state and actions via a localhost REST API, with an optional MCP server for Claude Desktop / Claude Code integration.
 
-Singleplayer and multiplayer (co-op) supported. Tested against STS2 `v0.103.2`.
+Singleplayer and multiplayer (co-op) supported. Tested against STS2 `v0.103.2` and `v0.104.0`.
 
 > [!warning]
 > This mod allows external programs to read and control your game via a localhost API. Use at your own risk with runs you care less about.


### PR DESCRIPTION
Hi! This updates STS2MCP for the STS2 v0.104.0 combat API change where `CombatManager.IsPlayPhase` is no longer available.

What changed:
- replace direct `IsPlayPhase` calls with a small helper based on combat state, player turn membership, and turn-ending/action-disabled flags
- update target resolution to accept `ICombatState`
- note v0.104.0 compatibility in the README

Validation:
- `dotnet build STS2_MCP.csproj -c Release -o out/STS2_MCP -p:STS2GameDir="$HOME/Library/Application Support/Steam/steamapps/common/Slay the Spire 2"`
- tested locally on macOS with STS2 v0.104.0 by reading combat state and playing through a combat via the REST API
