### PR TITLE
Multiplayer host/join/load lobby support

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1259,6 +1259,20 @@ public static partial class McpMod
             return Error($"Unknown timeline option: {option}. Use: advance, back");
         }
 
+        // Multiplayer Join Friend screen — friend list, refresh, back, or join_<index>/<player_id>.
+        var joinScreen = FindFirst<NJoinFriendScreen>(tree.Root);
+        if (joinScreen != null && IsNodeVisible(joinScreen))
+        {
+            return ExecuteJoinScreenMenuOption(joinScreen, option);
+        }
+
+        // Multiplayer Load Game lobby — confirm/embark/unready/back to resume saved MP run.
+        var loadLobby = FindFirst<NMultiplayerLoadGameScreen>(tree.Root);
+        if (loadLobby != null && IsNodeVisible(loadLobby))
+        {
+            return ExecuteLoadLobbyMenuOption(loadLobby, option);
+        }
+
         // Character select can outlive or be mounted separately from NMainMenu,
         // so handle it before main-menu-specific routing.
         var charSelect = FindFirst<NCharacterSelectScreen>(tree.Root);
@@ -1437,6 +1451,120 @@ public static partial class McpMod
         return Error($"Unknown profile select option: {option}. Use: profile_1, profile_2, profile_3, back");
     }
 
+    private static Dictionary<string, object?> ExecuteJoinScreenMenuOption(
+        NJoinFriendScreen joinScreen,
+        string option)
+    {
+        var normalized = option.ToLowerInvariant();
+
+        if (normalized == "back")
+        {
+            return ClickMenuButtonField(joinScreen, "_backButton", "Going back from join screen", "Back button is not available");
+        }
+
+        if (normalized == "refresh")
+        {
+            var refreshBtn = GetInstanceFieldValue(joinScreen, "_refreshButton") as NClickableControl;
+            if (refreshBtn != null && refreshBtn.IsEnabled && IsNodeVisible(refreshBtn))
+            {
+                refreshBtn.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Refreshing friend list" };
+            }
+            return Error("Refresh button not available");
+        }
+
+        // join_<index> or join_<player_id>
+        if (normalized.StartsWith("join_", System.StringComparison.Ordinal))
+        {
+            var key = normalized["join_".Length..];
+            var buttonContainer = GetInstanceFieldValue(joinScreen, "_buttonContainer") as Control;
+            if (buttonContainer == null)
+                return Error("Friend list container not available");
+
+            // Build the in-order friend list once
+            var friendButtons = new List<NJoinFriendButton>();
+            foreach (var child in buttonContainer.GetChildren())
+            {
+                if (child is NJoinFriendButton fbtn)
+                    friendButtons.Add(fbtn);
+            }
+
+            if (friendButtons.Count == 0)
+                return Error("No friends with open lobbies. Use 'refresh' to retry.");
+
+            // Try as index first
+            if (int.TryParse(key, out int idx))
+            {
+                if (idx < 0 || idx >= friendButtons.Count)
+                    return Error($"Friend index {idx} out of range (0..{friendButtons.Count - 1})");
+                if (!friendButtons[idx].IsEnabled)
+                    return Error($"Friend at index {idx} is not joinable right now");
+                friendButtons[idx].ForceClick();
+                return new Dictionary<string, object?>
+                {
+                    ["status"] = "ok",
+                    ["message"] = $"Joining friend at index {idx}"
+                };
+            }
+
+            // Otherwise treat as ulong player id
+            if (ulong.TryParse(key, out ulong playerId))
+            {
+                var match = friendButtons.FirstOrDefault(b => b.PlayerId == playerId);
+                if (match == null)
+                    return Error($"No friend with player_id {playerId} in current list. Available indices: 0..{friendButtons.Count - 1}");
+                if (!match.IsEnabled)
+                    return Error($"Friend {playerId} is not joinable right now");
+                match.ForceClick();
+                return new Dictionary<string, object?>
+                {
+                    ["status"] = "ok",
+                    ["message"] = $"Joining friend {playerId}"
+                };
+            }
+
+            return Error($"Unknown join target: '{key}'. Use join_<index> (e.g. join_0) or join_<player_id>.");
+        }
+
+        return Error($"Unknown join screen option: {option}. Use: refresh, back, join_<index>, join_<player_id>");
+    }
+
+    private static Dictionary<string, object?> ExecuteLoadLobbyMenuOption(
+        NMultiplayerLoadGameScreen loadLobby,
+        string option)
+    {
+        var normalized = option.ToLowerInvariant();
+
+        if (normalized == "confirm" || normalized == "embark" || normalized == "ready")
+        {
+            var confirmBtn = GetInstanceFieldValue(loadLobby, "_confirmButton") as NClickableControl;
+            if (confirmBtn != null && confirmBtn.IsEnabled && IsNodeVisible(confirmBtn))
+            {
+                confirmBtn.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Readied up to load saved MP run" };
+            }
+            return Error("Confirm button not available — already ready, or lobby not yet initialized");
+        }
+
+        if (normalized == "unready")
+        {
+            var unreadyBtn = GetInstanceFieldValue(loadLobby, "_unreadyButton") as NClickableControl;
+            if (unreadyBtn != null && unreadyBtn.IsEnabled && IsNodeVisible(unreadyBtn))
+            {
+                unreadyBtn.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Retracted ready vote" };
+            }
+            return Error("Unready button not available — you have not confirmed yet");
+        }
+
+        if (normalized == "back")
+        {
+            return ClickMenuButtonField(loadLobby, "_backButton", "Going back from load lobby", "Back button is not available");
+        }
+
+        return Error($"Unknown load lobby option: {option}. Use: confirm, embark, unready, back");
+    }
+
     private static Dictionary<string, object?> ExecuteCharacterSelectMenuOption(
         NCharacterSelectScreen charSelect,
         string option,
@@ -1444,14 +1572,35 @@ public static partial class McpMod
     {
         if (string.Equals(option, "back", System.StringComparison.OrdinalIgnoreCase))
         {
-            var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
-                ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
-            if (backBtn is NClickableControl backClickable && IsControlVisibleOrActionable(backClickable))
+            // _backButton leaves the lobby (and disconnects in MP). _unreadyButton is a
+            // separate control that only becomes enabled after the player has hit
+            // confirm/embark in MP — it retracts the ready vote without leaving. Surface
+            // them as distinct options so callers can pick deliberately. Fall back to
+            // unready when only it is actionable so older callers don't get stuck.
+            var backBtn = GetInstanceFieldValue(charSelect, "_backButton") as NClickableControl;
+            if (backBtn != null && backBtn.IsEnabled && IsControlVisibleOrActionable(backBtn))
             {
-                backClickable.ForceClick();
+                backBtn.ForceClick();
                 return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Going back" };
             }
+            var unreadyFallback = GetInstanceFieldValue(charSelect, "_unreadyButton") as NClickableControl;
+            if (unreadyFallback != null && unreadyFallback.IsEnabled && IsControlVisibleOrActionable(unreadyFallback))
+            {
+                unreadyFallback.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Retracted ready vote (back fell through to unready)" };
+            }
             return Error("Back button not available");
+        }
+
+        if (string.Equals(option, "unready", System.StringComparison.OrdinalIgnoreCase))
+        {
+            var unreadyBtn = GetInstanceFieldValue(charSelect, "_unreadyButton") as NClickableControl;
+            if (unreadyBtn != null && unreadyBtn.IsEnabled && IsControlVisibleOrActionable(unreadyBtn))
+            {
+                unreadyBtn.ForceClick();
+                return new Dictionary<string, object?> { ["status"] = "ok", ["message"] = "Retracted ready vote" };
+            }
+            return Error("Unready button not available — you have not confirmed yet");
         }
 
         if (string.Equals(option, "confirm", System.StringComparison.OrdinalIgnoreCase) ||

--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1375,6 +1375,7 @@ public static partial class McpMod
                 "timeline" => "_timelineButton",
                 "settings" => "_settingsButton",
                 "continue" => "_continueButton",
+                "abandon_run" => "_abandonRunButton",
                 "quit" => "_quitButton",
                 _ => null
             };

--- a/McpMod.Formatting.cs
+++ b/McpMod.Formatting.cs
@@ -196,6 +196,44 @@ public static partial class McpMod
             sb.AppendLine(msg.ToString());
         sb.AppendLine();
 
+        // MP lobby block — ready/ascension/roster — same shape on character_select and load_lobby
+        if (state.TryGetValue("lobby", out var lobbyObj) &&
+            lobbyObj is Dictionary<string, object?> lobby)
+        {
+            FormatLobbyMarkdown(sb, lobby);
+        }
+
+        // Multiplayer Join — friends list
+        if (state.TryGetValue("friends", out var friendsObj) &&
+            friendsObj is List<Dictionary<string, object?>> friends)
+        {
+            bool fastMp = state.TryGetValue("fast_mp", out var fastObj) && fastObj is true;
+            bool loading = state.TryGetValue("loading", out var loadingObj) && loadingObj is true;
+            bool noFriends = state.TryGetValue("no_friends", out var noObj) && noObj is true;
+
+            sb.AppendLine($"### Friends ({friends.Count})"
+                          + (fastMp ? "  _[FastMP — auto-joins localhost:33771]_" : "")
+                          + (loading ? "  _[loading...]_" : ""));
+            if (friends.Count == 0)
+            {
+                sb.AppendLine(noFriends
+                    ? "_No friends with open lobbies. Use `refresh` to retry._"
+                    : "_(empty)_");
+            }
+            else
+            {
+                foreach (var friend in friends)
+                {
+                    var idx = friend.GetValueOrDefault("index")?.ToString() ?? "?";
+                    var name = friend.GetValueOrDefault("name")?.ToString() ?? "(unknown)";
+                    var pid = friend.GetValueOrDefault("player_id")?.ToString() ?? "?";
+                    var enabled = !friend.TryGetValue("enabled", out var en) || en is not false;
+                    sb.AppendLine($"- `join_{idx}` **{name}** ({pid}){(enabled ? "" : " (disabled)")}");
+                }
+            }
+            sb.AppendLine();
+        }
+
         if (state.TryGetValue("options", out var optionsObj) && optionsObj != null)
             FormatMenuOptionsMarkdown(sb, optionsObj);
 
@@ -218,6 +256,56 @@ public static partial class McpMod
             sb.AppendLine("Use `menu_select` with an unlocked character ID or name, then `confirm`/`embark`.");
             sb.AppendLine();
         }
+    }
+
+    private static void FormatLobbyMarkdown(StringBuilder sb, Dictionary<string, object?> lobby)
+    {
+        var type = lobby.GetValueOrDefault("type")?.ToString() ?? "?";
+        var mode = lobby.GetValueOrDefault("game_mode")?.ToString() ?? "standard";
+        var asc = lobby.GetValueOrDefault("ascension")?.ToString() ?? "0";
+        var maxAsc = lobby.GetValueOrDefault("max_ascension")?.ToString();
+        var allReady = lobby.TryGetValue("all_ready", out var ar) && ar is true;
+        var aboutToBegin = lobby.TryGetValue("is_about_to_begin", out var ab) && ab is true;
+
+        sb.Append($"### Lobby ({type}, {mode}) — Ascension: {asc}");
+        if (!string.IsNullOrEmpty(maxAsc) && maxAsc != "0")
+            sb.Append($" / max {maxAsc}");
+        sb.AppendLine();
+        sb.AppendLine($"- All ready: **{allReady}**" + (aboutToBegin ? "  — about to begin" : ""));
+
+        // MP load lobby uses act/floor/connected_player_count/expected_player_count
+        if (lobby.TryGetValue("act", out var actObj))
+        {
+            var act = actObj?.ToString();
+            var floor = lobby.GetValueOrDefault("floor")?.ToString();
+            sb.AppendLine($"- Saved progress: act {act}, floor {floor}");
+        }
+        if (lobby.TryGetValue("connected_player_count", out var connObj))
+        {
+            var conn = connObj?.ToString();
+            var expected = lobby.GetValueOrDefault("expected_player_count")?.ToString();
+            sb.AppendLine($"- Connected: {conn}/{expected}");
+        }
+
+        if (lobby.TryGetValue("players", out var pObj) &&
+            pObj is List<Dictionary<string, object?>> pl &&
+            pl.Count > 0)
+        {
+            sb.AppendLine("- Players:");
+            foreach (var p in pl)
+            {
+                var local = p.TryGetValue("is_local", out var l) && l is true ? " (you)" : "";
+                var host = p.TryGetValue("is_host", out var h) && h is true ? " [host]" : "";
+                var ready = p.TryGetValue("is_ready", out var r) && r is true ? " ✓" : "";
+                var connected = p.TryGetValue("is_connected", out var c) ? (c is true ? "" : " (disconnected)") : "";
+                var name = p.GetValueOrDefault("platform_name")?.ToString();
+                var charName = p.GetValueOrDefault("character")?.ToString()
+                               ?? p.GetValueOrDefault("character_id")?.ToString() ?? "?";
+                var label = string.IsNullOrEmpty(name) ? p.GetValueOrDefault("id")?.ToString() ?? "?" : name;
+                sb.AppendLine($"  - {label}{local}{host}: {charName}{ready}{connected}");
+            }
+        }
+        sb.AppendLine();
     }
 
     private static void FormatGameOverMarkdown(StringBuilder sb, Dictionary<string, object?> state)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -41,6 +41,13 @@ using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Models.RelicPools;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+using MegaCrit.Sts2.Core.Multiplayer;
+using MegaCrit.Sts2.Core.Multiplayer.Game;
+using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
+using MegaCrit.Sts2.Core.Entities.Multiplayer;
+using MegaCrit.Sts2.Core.Platform;
+using MegaCrit.Sts2.Core.Platform.Steam;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Nodes.Screens.GameOverScreen;
 using MegaCrit.Sts2.Core.Nodes.Screens.Timeline;
 using MegaCrit.Sts2.Core.Nodes.Screens.Settings;
@@ -165,6 +172,28 @@ public static partial class McpMod
                         }
                     }
                 }
+                // Multiplayer Join Friend screen (lives in the same submenu stack as
+                // NMultiplayerSubmenu; pushed when the user clicks "join")
+                if (result.ContainsKey("menu_screen") == false)
+                {
+                    var joinScreen = FindFirst<NJoinFriendScreen>(tree.Root);
+                    if (joinScreen != null && IsNodeVisible(joinScreen))
+                    {
+                        AddMultiplayerJoinMenuState(result, joinScreen);
+                    }
+                }
+
+                // Multiplayer Load lobby — resume saved MP run. Pushed by NMultiplayerSubmenu
+                // when "load" is clicked (host) or by JoinFlow when joining a save in progress (client).
+                if (result.ContainsKey("menu_screen") == false)
+                {
+                    var loadLobby = FindFirst<NMultiplayerLoadGameScreen>(tree.Root);
+                    if (loadLobby != null && IsNodeVisible(loadLobby))
+                    {
+                        AddMultiplayerLoadLobbyMenuState(result, loadLobby);
+                    }
+                }
+
                 // Check for character select screen
                 if (result.ContainsKey("menu_screen") == false)
                 {
@@ -683,8 +712,11 @@ public static partial class McpMod
             });
         }
 
-        var backBtn = GetInstanceFieldValue(charSelect, "_backButton")
-            ?? GetInstanceFieldValue(charSelect, "_unreadyButton");
+        // _backButton and _unreadyButton are surfaced as distinct options so MP callers
+        // can distinguish "leave the lobby" from "retract my ready vote". In SP, only
+        // _backButton ever becomes enabled. See NCharacterSelectScreen.OnEmbarkPressed /
+        // OnUnreadyPressed for the toggle logic.
+        var backBtn = GetInstanceFieldValue(charSelect, "_backButton");
         if (backBtn is NClickableControl backClickable && IsNodeVisible(backClickable))
         {
             options.Add(new Dictionary<string, object?>
@@ -694,8 +726,311 @@ public static partial class McpMod
             });
         }
 
+        // MP lobby block — surfaces roster / ready state / ascension when this character
+        // select is part of a host or client lobby. SP runs leave the field absent.
+        bool isMpCharSelect = false;
+        try
+        {
+            var lobby = charSelect.Lobby;
+            if (lobby != null && lobby.NetService != null && lobby.NetService.Type.IsMultiplayer())
+            {
+                isMpCharSelect = true;
+                result["lobby"] = BuildStartRunLobbyState(lobby);
+            }
+        }
+        catch { }
+
+        // _unreadyButton is part of the scene in SP too but never becomes enabled there.
+        // Only surface it as an option in MP, where it has a real role.
+        if (isMpCharSelect)
+        {
+            var unreadyBtn = GetInstanceFieldValue(charSelect, "_unreadyButton");
+            if (unreadyBtn is NClickableControl unreadyClickable && IsNodeVisible(unreadyClickable))
+            {
+                options.Add(new Dictionary<string, object?>
+                {
+                    ["name"] = "unready",
+                    ["enabled"] = unreadyClickable.IsEnabled
+                });
+            }
+        }
+
         if (options.Count > 0)
             result["options"] = options;
+    }
+
+    private static Dictionary<string, object?> BuildStartRunLobbyState(StartRunLobby lobby)
+    {
+        var lobbyState = new Dictionary<string, object?>
+        {
+            ["type"] = lobby.NetService.Type switch
+            {
+                NetGameType.Host => "host",
+                NetGameType.Client => "client",
+                NetGameType.Singleplayer => "singleplayer",
+                _ => lobby.NetService.Type.ToString().ToLowerInvariant()
+            },
+            ["game_mode"] = lobby.GameMode.ToString().ToLowerInvariant(),
+            ["max_players"] = lobby.MaxPlayers,
+            ["ascension"] = lobby.Ascension,
+            ["max_ascension"] = lobby.MaxAscension,
+            ["all_ready"] = lobby.Players.Count > 0 && lobby.Players.All(p => p.isReady),
+            ["is_about_to_begin"] = SafeIsAboutToBeginGame(lobby)
+        };
+
+        // is_local_ready === local player has hit Embark in MP and is now waiting.
+        // Mirrors NCharacterSelectScreen._readyAndWaitingContainer.Visible.
+        try
+        {
+            var local = lobby.LocalPlayer;
+            lobbyState["is_local_ready"] = local.isReady;
+            lobbyState["local_player_id"] = local.id.ToString();
+        }
+        catch { }
+
+        var players = new List<Dictionary<string, object?>>();
+        ulong localId;
+        try { localId = lobby.LocalPlayer.id; } catch { localId = 0; }
+        ulong hostId = lobby.NetService.Type == NetGameType.Host ? localId : 0;
+
+        foreach (var p in lobby.Players)
+        {
+            var entry = new Dictionary<string, object?>
+            {
+                ["id"] = p.id.ToString(),
+                ["slot_id"] = p.slotId,
+                ["is_local"] = p.id == localId,
+                // We can only positively identify the host as "us" when we ARE the host;
+                // a client doesn't know which remote id is the host without inspecting
+                // the net service. Keep it simple and only flag is_host=true for self
+                // when hosting — clients can infer host-ness by player_id when needed.
+                ["is_host"] = p.id == hostId && hostId != 0,
+                ["character"] = SafeGetText(() => p.character?.Title)
+                                ?? p.character?.Id.Entry,
+                ["character_id"] = p.character?.Id.Entry,
+                ["is_ready"] = p.isReady,
+                ["platform_name"] = SafeGetPlayerName(lobby.NetService.Platform, p.id)
+            };
+            players.Add(entry);
+        }
+        lobbyState["players"] = players;
+        lobbyState["player_count"] = players.Count;
+
+        if (!string.IsNullOrEmpty(lobby.Seed))
+            lobbyState["seed"] = lobby.Seed;
+
+        return lobbyState;
+    }
+
+    private static bool SafeIsAboutToBeginGame(StartRunLobby lobby)
+    {
+        try { return lobby.IsAboutToBeginGame(); }
+        catch { return false; }
+    }
+
+    private static string? SafeGetPlayerName(PlatformType platform, ulong playerId)
+    {
+        try { return PlatformUtil.GetPlayerName(platform, playerId); }
+        catch { return null; }
+    }
+
+    private static void AddMultiplayerJoinMenuState(
+        Dictionary<string, object?> result,
+        NJoinFriendScreen joinScreen)
+    {
+        result["state_type"] = "menu";
+        result["menu_screen"] = "multiplayer_join";
+
+        // FastMP: when Steam isn't initialized OR --fastmp is set, OnSubmenuOpened auto-
+        // joins localhost:33771 instead of presenting friends. This is a debug/local-dev
+        // path. We surface it so callers don't try to hit "refresh" expecting a list.
+        bool fastMp = !SteamInitializer.Initialized || CommandLineHelper.HasArg("fastmp");
+        result["fast_mp"] = fastMp;
+
+        var loadingFriends = GetInstanceFieldValue(joinScreen, "_loadingFriendsIndicator") as Control;
+        var loadingOverlay = GetInstanceFieldValue(joinScreen, "_loadingOverlay") as Control;
+        bool loading = (loadingFriends != null && loadingFriends.Visible)
+                       || (loadingOverlay != null && loadingOverlay.Visible);
+        result["loading"] = loading;
+
+        var noFriendsLabel = GetInstanceFieldValue(joinScreen, "_noFriendsLabel") as Control;
+        bool noFriends = noFriendsLabel != null && noFriendsLabel.Visible;
+        result["no_friends"] = noFriends;
+
+        var friends = new List<Dictionary<string, object?>>();
+        var options = new List<Dictionary<string, object?>>();
+
+        var buttonContainer = GetInstanceFieldValue(joinScreen, "_buttonContainer") as Control;
+        if (buttonContainer != null)
+        {
+            int index = 0;
+            foreach (var child in buttonContainer.GetChildren())
+            {
+                if (child is NJoinFriendButton friendBtn)
+                {
+                    string? name = null;
+                    try { name = PlatformUtil.GetPlayerName(PlatformUtil.PrimaryPlatform, friendBtn.PlayerId); }
+                    catch { }
+
+                    friends.Add(new Dictionary<string, object?>
+                    {
+                        ["index"] = index,
+                        ["name"] = name,
+                        ["player_id"] = friendBtn.PlayerId.ToString(),
+                        ["enabled"] = friendBtn.IsEnabled
+                    });
+                    options.Add(new Dictionary<string, object?>
+                    {
+                        ["name"] = $"join_{index}",
+                        ["enabled"] = friendBtn.IsEnabled
+                    });
+                    index++;
+                }
+            }
+        }
+        result["friends"] = friends;
+
+        var refreshBtn = GetInstanceFieldValue(joinScreen, "_refreshButton") as NClickableControl;
+        if (refreshBtn != null && IsNodeVisible(refreshBtn))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "refresh",
+                ["enabled"] = refreshBtn.IsEnabled && !loading
+            });
+        }
+        AddMenuOptionIfVisible(options, joinScreen, "_backButton", "back");
+
+        if (fastMp)
+        {
+            result["message"] = loading
+                ? "FastMP join flow is connecting to localhost:33771..."
+                : "FastMP mode (no Steam): join screen auto-connects to localhost:33771.";
+        }
+        else if (loading)
+        {
+            result["message"] = "Refreshing friend list...";
+        }
+        else if (noFriends)
+        {
+            result["message"] = "No friends with open lobbies. Use 'refresh' to retry, or 'back' to return.";
+        }
+        else
+        {
+            result["message"] = "Pick a friend to join, or 'refresh' to update the list.";
+        }
+
+        result["options"] = options;
+    }
+
+    private static void AddMultiplayerLoadLobbyMenuState(
+        Dictionary<string, object?> result,
+        NMultiplayerLoadGameScreen loadLobby)
+    {
+        result["state_type"] = "menu";
+        result["menu_screen"] = "multiplayer_load_lobby";
+
+        var lobby = GetInstanceFieldValue(loadLobby, "_runLobby") as LoadRunLobby;
+        if (lobby != null)
+        {
+            var info = new Dictionary<string, object?>
+            {
+                ["type"] = lobby.NetService.Type switch
+                {
+                    NetGameType.Host => "host",
+                    NetGameType.Client => "client",
+                    _ => lobby.NetService.Type.ToString().ToLowerInvariant()
+                },
+                ["game_mode"] = lobby.GameMode.ToString().ToLowerInvariant(),
+                ["ascension"] = lobby.Run?.Ascension ?? 0,
+                ["act"] = (lobby.Run?.CurrentActIndex ?? 0) + 1,
+                ["floor"] = lobby.Run?.VisitedMapCoords?.Count ?? 0
+            };
+
+            try
+            {
+                var localPlayer = lobby.Run?.Players?.FirstOrDefault(p => p.NetId == lobby.NetService.NetId);
+                if (localPlayer != null)
+                {
+                    info["character_id"] = localPlayer.CharacterId?.Entry;
+                    info["current_hp"] = localPlayer.CurrentHp;
+                    info["max_hp"] = localPlayer.MaxHp;
+                    info["gold"] = localPlayer.Gold;
+                }
+            }
+            catch { }
+
+            info["expected_player_count"] = lobby.Run?.Players?.Count ?? 0;
+            info["connected_player_count"] = lobby.ConnectedPlayerIds?.Count ?? 0;
+
+            // Per-player ready/connected breakdown
+            var players = new List<Dictionary<string, object?>>();
+            try
+            {
+                if (lobby.Run?.Players != null)
+                {
+                    foreach (var sp in lobby.Run.Players)
+                    {
+                        bool isConnected = lobby.ConnectedPlayerIds?.Contains(sp.NetId) ?? false;
+                        bool isReady = false;
+                        try { isReady = lobby.IsPlayerReady(sp.NetId); } catch { }
+                        players.Add(new Dictionary<string, object?>
+                        {
+                            ["id"] = sp.NetId.ToString(),
+                            ["is_local"] = sp.NetId == lobby.NetService.NetId,
+                            ["character_id"] = sp.CharacterId?.Entry,
+                            ["is_connected"] = isConnected,
+                            ["is_ready"] = isReady,
+                            ["platform_name"] = SafeGetPlayerName(lobby.NetService.Platform, sp.NetId)
+                        });
+                    }
+                }
+            }
+            catch { }
+            info["players"] = players;
+
+            result["lobby"] = info;
+        }
+
+        var options = new List<Dictionary<string, object?>>();
+
+        var confirmBtn = GetInstanceFieldValue(loadLobby, "_confirmButton") as NClickableControl;
+        if (confirmBtn != null && IsNodeVisible(confirmBtn))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "confirm",
+                ["enabled"] = confirmBtn.IsEnabled
+            });
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "embark",
+                ["enabled"] = confirmBtn.IsEnabled
+            });
+        }
+
+        var backBtn2 = GetInstanceFieldValue(loadLobby, "_backButton") as NClickableControl;
+        if (backBtn2 != null && IsNodeVisible(backBtn2))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "back",
+                ["enabled"] = backBtn2.IsEnabled
+            });
+        }
+
+        var unreadyBtn2 = GetInstanceFieldValue(loadLobby, "_unreadyButton") as NClickableControl;
+        if (unreadyBtn2 != null && IsNodeVisible(unreadyBtn2))
+        {
+            options.Add(new Dictionary<string, object?>
+            {
+                ["name"] = "unready",
+                ["enabled"] = unreadyBtn2.IsEnabled
+            });
+        }
+
+        result["options"] = options;
+        result["message"] = "Multiplayer load lobby. Confirm to ready up; once everyone is connected and ready, the run resumes.";
     }
 
     private static Dictionary<string, object?> BuildBattleState(RunState runState, CombatRoom combatRoom)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -338,8 +338,8 @@ public static partial class McpMod
                         {
                             var options = new List<string>();
                             var blockedOptions = new List<Dictionary<string, object?>>();
-                            var fields = new[] { "_continueButton", "_singleplayerButton", "_multiplayerButton", "_compendiumButton", "_timelineButton", "_settingsButton", "_quitButton" };
-                            var labels = new[] { "continue", "singleplayer", "multiplayer", "compendium", "timeline", "settings", "quit" };
+                            var fields = new[] { "_continueButton", "_abandonRunButton", "_singleplayerButton", "_multiplayerButton", "_compendiumButton", "_timelineButton", "_settingsButton", "_quitButton" };
+                            var labels = new[] { "continue", "abandon_run", "singleplayer", "multiplayer", "compendium", "timeline", "settings", "quit" };
                             var unrevealedEpochs = GetProgressEpochIdsByState("Obtained", "ObtainedNoSlot");
                             for (int i = 0; i < fields.Length; i++)
                             {
@@ -962,6 +962,15 @@ public static partial class McpMod
 
             info["expected_player_count"] = lobby.Run?.Players?.Count ?? 0;
             info["connected_player_count"] = lobby.ConnectedPlayerIds?.Count ?? 0;
+
+            // IsAboutToBeginGame == "no players still in handshake AND every connected player is ready".
+            // It's the literal trigger for the host's TryBeginRun, so it doubles as both "all_ready" (matches
+            // the StartRunLobby semantic of 'every joined player is ready') and "is_about_to_begin".
+            // Without these fields, FormatLobbyMarkdown printed "All ready: false" unconditionally for load lobbies.
+            bool aboutToBegin = false;
+            try { aboutToBegin = lobby.IsAboutToBeginGame(); } catch { }
+            info["all_ready"] = aboutToBegin;
+            info["is_about_to_begin"] = aboutToBegin;
 
             // Per-player ready/connected breakdown
             var players = new List<Dictionary<string, object?>>();

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -19,7 +19,7 @@ namespace STS2_MCP;
 [ModInitializer("Initialize")]
 public static partial class McpMod
 {
-    public const string Version = "0.3.4";
+    public const string Version = "0.4.0";
     public const int DefaultPort = 15526;
     private const string ConfigFileName = "STS2_MCP.conf";
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A mod for [**Slay the Spire 2**](https://store.steampowered.com/app/2868840/Slay_the_Spire_2/) that lets AI agents play the game. Exposes game state and actions via a localhost REST API, with an optional MCP server for Claude Desktop / Claude Code integration.
 
-Singleplayer and multiplayer (co-op) supported, plus main-menu control: profile switching, character select with optional seed, game-over dismissal, FTUE/tutorial popup handling, and Timeline visibility. Tested against STS2 `v0.103.2`.
+Singleplayer and multiplayer (co-op) supported, plus full menu and lobby control: profile switching, character select (SP and MP host/client) with optional seed, multiplayer host / Steam-friend join / FastMP localhost join, multiplayer load lobby for resuming saved co-op runs, game-over dismissal, FTUE/tutorial popup handling, and Timeline visibility. Tested against STS2 `v0.103.2`.
 
 > [!warning]
 > This mod allows external programs to read and control your game via a localhost API. Use at your own risk with runs you care less about.

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -196,11 +196,128 @@ Menu sub-screens expose their own options:
 - `singleplayer`: `standard`, `daily`, `custom`, `back`
 - `multiplayer`: `host`, `join`, `load`, `abandon`, `back`
 - `multiplayer_host`: `standard`, `daily`, `custom`, `back`
+- `multiplayer_join`: `refresh`, `back`, `join_<index>`, `join_<player_id>`
+- `multiplayer_load_lobby`: `confirm` / `embark`, `unready`, `back`
 - `profile_select`: `profile_1`, `profile_2`, `profile_3`, `back`
-- `character_select`: character IDs/names, `back`, `confirm`, `embark`
+- `character_select`: character IDs/names, `back`, `confirm` / `embark`, `unready` (MP, after readying)
 - `tutorial_prompt`: `no`, `yes`
 - `popup`: advertised popup button labels, normalized to lowercase words such as `ignore` or `back`
 - `timeline`: `advance`, `back`
+
+The `multiplayer` submenu is gated on whether a multiplayer save exists: with no save, `host` is shown and `load` / `abandon` are hidden; with a save, those are shown and `host` is hidden. `abandon` opens a vertical popup — the next state turn surfaces the popup's `confirm` / `cancel` options, not a transition.
+
+#### `multiplayer_join` — Friend list / FastMP
+
+```jsonc
+{
+  "state_type": "menu",
+  "menu_screen": "multiplayer_join",
+  "message": "Pick a friend to join, or 'refresh' to update the list.",
+  "fast_mp": false,             // true when --fastmp / Steam not initialized; auto-joins 127.0.0.1:33771
+  "loading": false,             // true while refreshing or while a join handshake is in flight
+  "no_friends": false,          // true when refresh returned an empty list
+  "friends": [
+    { "index": 0, "name": "Bob", "player_id": "76561198000000000", "enabled": true }
+  ],
+  "options": [
+    { "name": "join_0",  "enabled": true },
+    { "name": "refresh", "enabled": true },
+    { "name": "back",    "enabled": true }
+  ]
+}
+```
+
+`menu_select` accepts either `join_<index>` (e.g. `join_0`) or `join_<player_id>` (e.g. `join_76561198000000000`) — both click the same button. With `fast_mp: true`, the screen auto-joins localhost on open; you typically won't need to issue a join action in that mode.
+
+#### `multiplayer_load_lobby` — Resume saved MP run
+
+Reached via the `multiplayer` submenu's `load` option (host) or by joining a host that already loaded a save (client). Mirrors the standard MP character-select ready/unready flow but on a fixed (saved) party.
+
+```jsonc
+{
+  "state_type": "menu",
+  "menu_screen": "multiplayer_load_lobby",
+  "message": "Multiplayer load lobby. Confirm to ready up; ...",
+  "lobby": {
+    "type": "host",                // or "client"
+    "game_mode": "standard",       // or "daily" / "custom"
+    "ascension": 0,
+    "act": 2,
+    "floor": 13,
+    "character_id": "REGENT",      // local player's saved character
+    "current_hp": 64,
+    "max_hp": 80,
+    "gold": 240,
+    "expected_player_count": 3,
+    "connected_player_count": 2,
+    "players": [
+      {
+        "id": "76561198000000000",
+        "is_local": true,
+        "character_id": "REGENT",
+        "is_connected": true,
+        "is_ready": false,
+        "platform_name": "Alice"
+      }
+    ]
+  },
+  "options": [
+    { "name": "confirm", "enabled": true },
+    { "name": "embark",  "enabled": true },   // alias of confirm
+    { "name": "back",    "enabled": true },
+    { "name": "unready", "enabled": false }   // becomes enabled after confirm/embark
+  ]
+}
+```
+
+#### `character_select` — extended for MP
+
+The same screen drives SP, MP host, and MP client. In MP, an additional `lobby` block appears, and the `unready` option becomes available after the local player has hit `confirm`/`embark`:
+
+```jsonc
+{
+  "state_type": "menu",
+  "menu_screen": "character_select",
+  "message": "Select a character.",
+  "characters": [ /* same shape as SP */ ],
+  "lobby": {                       // present only in MP
+    "type": "host",                // "host" | "client" | "singleplayer"
+    "game_mode": "standard",       // "standard" | "daily" | "custom"
+    "max_players": 4,
+    "ascension": 0,
+    "max_ascension": 5,            // min across all lobby members' MaxMultiplayerAscension
+    "all_ready": false,
+    "is_about_to_begin": false,    // mirrors StartRunLobby.IsAboutToBeginGame()
+    "is_local_ready": false,
+    "local_player_id": "76561198000000000",
+    "player_count": 2,
+    "seed": "...",                 // optional, present only for daily/custom
+    "players": [
+      {
+        "id": "76561198000000000",
+        "slot_id": 0,
+        "is_local": true,
+        "is_host": true,           // only positively true for self when hosting; otherwise false
+        "character": "The Regent",
+        "character_id": "REGENT",
+        "is_ready": false,
+        "platform_name": "Alice"
+      }
+    ]
+  },
+  "options": [
+    { "name": "REGENT",  "enabled": true },
+    { "name": "IRONCLAD","enabled": true },
+    /* ... other characters and lockable RANDOM ... */
+    { "name": "confirm", "enabled": true },
+    { "name": "embark",  "enabled": true },
+    { "name": "back",    "enabled": true },
+    { "name": "unready", "enabled": false }
+  ]
+}
+```
+
+In SP the `lobby` field is omitted, and `unready` does not appear (the unready button is only enabled after MP ready).
 
 ### `unknown`
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -27,7 +27,7 @@ Every JSON response includes:
 
 | `state_type` | Screen | Available Actions |
 |---|---|---|
-| `menu` | Main menu, menu submenu, or a blocking FTUE/tutorial/popup that can also appear mid-run | `menu_select` |
+| `menu` | Main menu, menu submenu (incl. multiplayer host/join/load lobby), character select, or a blocking FTUE/tutorial/popup that can also appear mid-run | `menu_select` |
 | `unknown` | Unrecognized room or null state | None |
 | `monster` / `elite` / `boss` | In combat | `play_card`, `use_potion`, `end_turn` |
 | `hand_select` | In-combat card selection (exhaust, discard, upgrade) | `combat_select_card`, `combat_confirm_selection` |
@@ -56,7 +56,7 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 | Action | Parameters | When to Use |
 |---|---|---|
-| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. Blocking popups expose normalized button labels such as `ignore` or `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. If Timeline has pending obtained epochs that require manual reveal, it may appear in `blocked_options`; selecting `timeline` returns `manual_action_required: true` with `pending_epoch_ids` instead of opening Timeline. |
+| `menu_select` | `option`: string, `seed`?: string | Choose an advertised menu option. Options are case-insensitive. Submenus include `back` where visible, including `profile_select` options `profile_1`, `profile_2`, `profile_3`, and `back`. Blocking popups expose normalized button labels such as `ignore` or `back`. `game_over` supports `main_menu` only; `continue` returns an error. Supplying `seed` in unsupported contexts such as standard singleplayer character select returns an error and does not start a run. If Timeline has pending obtained epochs that require manual reveal, it may appear in `blocked_options`; selecting `timeline` returns `manual_action_required: true` with `pending_epoch_ids` instead of opening Timeline. Multiplayer flow: on `multiplayer_join` use `refresh` / `back` / `join_<index>` / `join_<player_id>`. On `multiplayer_load_lobby` use `confirm` (or `embark`) to ready up, `unready` to retract, `back` to leave. On `character_select` while in MP, an additional `unready` option becomes available after readying, plus a `lobby` block in state lists ascension, all_ready, and per-player roster. |
 
 ### Profiles
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -155,9 +155,20 @@ async def get_game_state(format: str = "markdown") -> str:
 async def menu_select(option: str, seed: str | None = None) -> str:
     """Select a visible menu option.
 
-    Use with state_type "menu" or "game_over". Supports main-menu navigation,
-    singleplayer and multiplayer submenus, character select, timeline controls,
-    tutorial prompts, and game-over main-menu return.
+    Use with state_type "menu" or "game_over". Covers main-menu navigation,
+    singleplayer / multiplayer submenus, multiplayer host & join lobbies,
+    multiplayer load lobby (resume saved co-op run), character select for SP
+    and MP (with `unready` once readied in MP), profile switching, timeline
+    controls, tutorial prompts, blocking popups, and game-over main-menu return.
+
+    Multiplayer flow tips:
+      - On menu_screen "multiplayer_join", use refresh / back / join_<index> /
+        join_<player_id> (e.g. "join_0" or "join_76561198000000000").
+      - On menu_screen "multiplayer_load_lobby", use confirm (or embark) to
+        ready up; the run resumes once everyone is connected and ready.
+      - On menu_screen "character_select" while in MP, the state includes a
+        `lobby` block with the roster, ready states, and ascension; "unready"
+        becomes available after you confirm/embark.
 
     Args:
         option: Option ID from the current menu state's options list. If an

--- a/mod_manifest.json
+++ b/mod_manifest.json
@@ -3,7 +3,7 @@
   "name": "STS2 MCP",
   "author": "kunology",
   "description": "MCP server bridge for Slay the Spire 2",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "has_pck": false,
   "has_dll": true,
   "affects_gameplay": false


### PR DESCRIPTION
Drives the full pre-run multiplayer flow through the existing `menu_select` action. No new endpoints, no new MCP tools. Lets agents host an MP lobby, browse and join Steam friends (or auto-connect to localhost in FastMP), pick characters with live roster awareness, ready/unready, and resume saved co-op runs from the load lobby.

Refs the previously-deserted #52, supersedes that exploration with a fresh implementation that mirrors the UI paths and menu action signatures from #71.