### PR TITLE
[codex] Allow port configuration from dotenv

### DIFF
--- a/McpMod.cs
+++ b/McpMod.cs
@@ -22,6 +22,8 @@ public static partial class McpMod
     public const string Version = "0.4.0";
     public const int DefaultPort = 15526;
     private const string ConfigFileName = "STS2_MCP.conf";
+    private const string DotEnvFileName = ".env";
+    private const string PortEnvVar = "STS2_PORT";
 
     private static HttpListener? _listener;
     private static Thread? _serverThread;
@@ -40,6 +42,13 @@ public static partial class McpMod
         {
             string? modDir = Path.GetDirectoryName(
                 System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+            if (TryLoadPortFromEnvironment(out int envPort))
+                return envPort;
+
+            if (TryLoadPortFromDotEnv(modDir, out int dotEnvPort))
+                return dotEnvPort;
+
             if (modDir == null) return DefaultPort;
 
             string configPath = Path.Combine(modDir, ConfigFileName);
@@ -76,6 +85,94 @@ public static partial class McpMod
             GD.PrintErr($"[STS2 MCP] Failed to load config: {ex.Message}, using default port {DefaultPort}");
             return DefaultPort;
         }
+    }
+
+    private static bool TryLoadPortFromEnvironment(out int port)
+    {
+        var configured = System.Environment.GetEnvironmentVariable(PortEnvVar);
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            port = 0;
+            return false;
+        }
+
+        return TryParseConfiguredPort(configured, PortEnvVar, out port);
+    }
+
+    private static bool TryLoadPortFromDotEnv(string? modDir, out int port)
+    {
+        foreach (var envPath in GetDotEnvPaths(modDir))
+        {
+            try
+            {
+                if (!File.Exists(envPath))
+                    continue;
+
+                foreach (var line in File.ReadLines(envPath))
+                {
+                    var stripped = line.Trim();
+                    if (stripped.Length == 0 || stripped.StartsWith("#", StringComparison.Ordinal) || !stripped.Contains('='))
+                        continue;
+
+                    var separator = stripped.IndexOf('=');
+                    var key = stripped[..separator].Trim();
+                    if (key.StartsWith("export ", StringComparison.Ordinal))
+                        key = key["export ".Length..].Trim();
+
+                    if (!string.Equals(key, PortEnvVar, StringComparison.Ordinal))
+                        continue;
+
+                    var value = ParseDotEnvValue(stripped[(separator + 1)..]);
+                    return TryParseConfiguredPort(value, $"{envPath}:{PortEnvVar}", out port);
+                }
+            }
+            catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+            {
+                GD.PrintErr($"[STS2 MCP] Failed to read {envPath}: {ex.Message}");
+            }
+        }
+
+        port = 0;
+        return false;
+    }
+
+    private static IEnumerable<string> GetDotEnvPaths(string? modDir)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        if (!string.IsNullOrWhiteSpace(modDir))
+        {
+            var modEnvPath = Path.Combine(modDir, DotEnvFileName);
+            if (seen.Add(modEnvPath))
+                yield return modEnvPath;
+        }
+
+        var cwdEnvPath = Path.Combine(System.Environment.CurrentDirectory, DotEnvFileName);
+        if (seen.Add(cwdEnvPath))
+            yield return cwdEnvPath;
+    }
+
+    private static string ParseDotEnvValue(string rawValue)
+    {
+        var value = rawValue.Trim();
+        if (value.Length >= 2 && value[0] == value[^1] && (value[0] == '\'' || value[0] == '"'))
+            return value[1..^1];
+
+        var commentIndex = value.IndexOf('#');
+        if (commentIndex >= 0)
+            value = value[..commentIndex].TrimEnd();
+
+        return value;
+    }
+
+    private static bool TryParseConfiguredPort(string value, string source, out int port)
+    {
+        if (int.TryParse(value.Trim(), out port) && port is > 0 and <= 65535)
+            return true;
+
+        GD.PrintErr($"[STS2 MCP] Invalid port value from {source}: {value}; using next configured port source");
+        port = 0;
+        return false;
     }
 
     public static void Initialize()

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Grab the [latest release](https://github.com/Gennadiyev/STS2MCP/releases/latest)
 2. Launch the game and enable mods in settings (a consent dialog appears on first launch)
 3. The mod starts an HTTP server on `localhost:15526` automatically
 
+To use a different game API port on the next launch, set `STS2_PORT` in the game process environment or create a `.env` file next to the installed `STS2_MCP.dll`:
+
+```dotenv
+STS2_PORT=15527
+```
+
+Shell environment variables take precedence over `.env`, and the legacy `STS2_MCP.conf` port remains supported when `STS2_PORT` is unset.
+
 > [!note]
 > The release DLL is a platform-agnostic .NET assembly — the same `STS2_MCP.dll` and `STS2_MCP.json` work on Windows, Linux, and macOS. No separate builds are needed.
 


### PR DESCRIPTION
## Summary
- Read `STS2_PORT` in the C# mod before falling back to `STS2_MCP.conf` and the default port.
- Support `.env` files next to the installed mod DLL and in the game working directory, including `export`, quoted values, and inline comments.
- Document custom game API port setup for the next game launch.

## Validation
- Attempted `"/mnt/c/Program Files/dotnet/dotnet.exe" build STS2_MCP.csproj -c Release --no-restore`; this upstream-based checkout fails before this change on `McpMod.StateBuilder.cs` because the local game assembly lacks `LoadRunLobby.IsAboutToBeginGame`.
- Attempted `uv run --project mcp python scripts/test_mcp_server.py`; this upstream-based checkout does not contain `scripts/test_mcp_server.py`.

## Notes
- This only changes startup port resolution. It does not restart or alter an already-running game server.