### PR TITLE
[codex] Add compendium endpoint

### DIFF
--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -1,0 +1,437 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using MegaCrit.Sts2.Core.Saves;
+using MegaCrit.Sts2.Core.Saves.Managers;
+
+namespace STS2_MCP;
+
+public static partial class McpMod
+{
+    private static void HandleGetCompendium(HttpListenerResponse response)
+    {
+        try
+        {
+            var dataTask = RunOnMainThread(BuildCompendium);
+            SendJson(response, dataTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            SendError(response, 500, $"Failed to build compendium: {ex.Message}");
+        }
+    }
+
+    internal static object BuildCompendium()
+    {
+        var progress = SaveManager.Instance?.Progress;
+        var saveManager = SaveManager.Instance;
+        if (progress == null || saveManager == null)
+            return new Dictionary<string, object?> { ["error"] = "No profile data available." };
+
+        var cardStats = progress.CardStats.Select(kv => new Dictionary<string, object?>
+        {
+            ["id"] = kv.Key.Entry,
+            ["times_picked"] = kv.Value.TimesPicked,
+            ["times_skipped"] = kv.Value.TimesSkipped,
+            ["times_won"] = kv.Value.TimesWon,
+            ["times_lost"] = kv.Value.TimesLost
+        }).ToList();
+
+        var characterStats = progress.CharacterStats.Select(kv => new Dictionary<string, object?>
+        {
+            ["id"] = kv.Key.Entry,
+            ["max_ascension"] = kv.Value.MaxAscension,
+            ["preferred_ascension"] = kv.Value.PreferredAscension,
+            ["total_wins"] = kv.Value.TotalWins,
+            ["total_losses"] = kv.Value.TotalLosses,
+            ["fastest_win_time"] = kv.Value.FastestWinTime,
+            ["best_win_streak"] = kv.Value.BestWinStreak,
+            ["current_win_streak"] = kv.Value.CurrentWinStreak,
+            ["playtime"] = kv.Value.Playtime
+        }).ToList();
+
+        var runHistory = BuildRunHistorySection(progress, saveManager.CurrentProfileId);
+
+        return new Dictionary<string, object?>
+        {
+            ["profile_id"] = saveManager.CurrentProfileId,
+            ["source"] = "SaveManager.Progress plus model metadata endpoints",
+            ["sections"] = new Dictionary<string, object?>
+            {
+                ["card_library"] = new Dictionary<string, object?>
+                {
+                    ["ui_label"] = "Card Library",
+                    ["status"] = "exposed",
+                    ["source"] = "/api/v1/profile card_stats and discovered_cards",
+                    ["detail_endpoint"] = "/api/v1/glossary/cards",
+                    ["detail_endpoint_requires_run"] = true,
+                    ["discovered_ids"] = progress.DiscoveredCards.Select(id => id.Entry).ToList(),
+                    ["stats"] = cardStats
+                },
+                ["relic_collection"] = new Dictionary<string, object?>
+                {
+                    ["ui_label"] = "Relic Collection",
+                    ["status"] = "partially_exposed",
+                    ["source"] = "/api/v1/profile discovered_relics",
+                    ["detail_endpoint"] = "/api/v1/glossary/relics",
+                    ["detail_endpoint_requires_run"] = true,
+                    ["discovered_ids"] = progress.DiscoveredRelics.Select(id => id.Entry).ToList(),
+                    ["limitation"] = "Profile exposes discovered relic IDs; per-relic obtained counts are not exposed by a typed API here."
+                },
+                ["potion_lab"] = new Dictionary<string, object?>
+                {
+                    ["ui_label"] = "Potion Lab",
+                    ["status"] = "partially_exposed",
+                    ["source"] = "/api/v1/profile discovered_potions",
+                    ["detail_endpoint"] = "/api/v1/glossary/potions",
+                    ["detail_endpoint_requires_run"] = true,
+                    ["discovered_ids"] = progress.DiscoveredPotions.Select(id => id.Entry).ToList(),
+                    ["limitation"] = "Profile exposes discovered potion IDs; per-potion lab UI metadata is not exposed by a typed API here."
+                },
+                ["bestiary"] = new Dictionary<string, object?>
+                {
+                    ["ui_label"] = "Bestiary",
+                    ["status"] = "locked_in_ui",
+                    ["source"] = "/api/v1/bestiary model metadata",
+                    ["detail_endpoint"] = "/api/v1/bestiary",
+                    ["encounter_stats"] = BuildEncounterStats(progress),
+                    ["enemy_stats"] = BuildEnemyStats(progress),
+                    ["limitation"] = "The current game UI labels Bestiary as future/locked; the endpoint exposes reflected model metadata and profile fight stats when available."
+                },
+                ["character_stats"] = new Dictionary<string, object?>
+                {
+                    ["ui_label"] = "Character Stats",
+                    ["status"] = "exposed",
+                    ["source"] = "/api/v1/profile characters and global totals",
+                    ["characters"] = characterStats,
+                    ["global"] = new Dictionary<string, object?>
+                    {
+                        ["total_playtime"] = progress.TotalPlaytime,
+                        ["total_unlocks"] = progress.TotalUnlocks,
+                        ["current_score"] = progress.CurrentScore,
+                        ["floors_climbed"] = progress.FloorsClimbed,
+                        ["architect_damage"] = progress.ArchitectDamage,
+                        ["total_wins"] = progress.Wins,
+                        ["total_losses"] = progress.Losses,
+                        ["fastest_victory"] = progress.FastestVictory,
+                        ["best_win_streak"] = progress.BestWinStreak,
+                        ["number_of_runs"] = progress.NumberOfRuns
+                    }
+                },
+                ["run_history"] = runHistory
+            }
+        };
+    }
+
+    private static List<Dictionary<string, object?>> BuildEncounterStats(dynamic progress)
+    {
+        var result = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.EncounterStats)
+            result.Add(BuildFightStatsEntry(kv.Key.Entry, kv.Value));
+        return result;
+    }
+
+    private static List<Dictionary<string, object?>> BuildEnemyStats(dynamic progress)
+    {
+        var result = new List<Dictionary<string, object?>>();
+        foreach (var kv in progress.EnemyStats)
+            result.Add(BuildFightStatsEntry(kv.Key.Entry, kv.Value));
+        return result;
+    }
+
+    private static Dictionary<string, object?> BuildFightStatsEntry(string id, dynamic stats)
+    {
+        var entry = new Dictionary<string, object?>
+        {
+            ["id"] = id,
+            ["total_wins"] = stats.TotalWins,
+            ["total_losses"] = stats.TotalLosses
+        };
+
+        var byCharacter = new List<Dictionary<string, object?>>();
+        foreach (var fs in stats.FightStats)
+        {
+            byCharacter.Add(new Dictionary<string, object?>
+            {
+                ["character"] = fs.Character.Entry,
+                ["wins"] = fs.Wins,
+                ["losses"] = fs.Losses
+            });
+        }
+        if (byCharacter.Count > 0)
+            entry["by_character"] = byCharacter;
+
+        return entry;
+    }
+
+    private static Dictionary<string, object?> BuildRunHistorySection(object progress, int profileId)
+    {
+        var members = progress.GetType()
+            .GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(member => member.Name.Contains("RunHistory", StringComparison.OrdinalIgnoreCase)
+                || member.Name.Contains("RunHistories", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var values = new Dictionary<string, object?>();
+        foreach (var member in members)
+        {
+            try
+            {
+                object? value = member switch
+                {
+                    PropertyInfo property when property.GetIndexParameters().Length == 0 => property.GetValue(progress),
+                    FieldInfo field => field.GetValue(progress),
+                    _ => null
+                };
+                if (value != null)
+                    values[member.Name] = ToJsonSafe(value, 0, 50);
+            }
+            catch { }
+        }
+
+        var historyDirectory = FindRunHistoryDirectory(profileId);
+        if (historyDirectory != null)
+        {
+            var files = Directory.GetFiles(historyDirectory, "*.run")
+                .Select(path => new FileInfo(path))
+                .OrderByDescending(file => file.LastWriteTimeUtc)
+                .ToList();
+
+            return new Dictionary<string, object?>
+            {
+                ["ui_label"] = "Run History",
+                ["status"] = files.Count > 0 ? "exposed" : "exposed_empty",
+                ["source"] = "Profile save history files",
+                ["history_path"] = historyDirectory,
+                ["entry_count"] = files.Count,
+                ["entries"] = files.Take(20).Select(BuildRunHistoryEntry).ToList(),
+                ["progress_members"] = values.Count > 0 ? values : null,
+                ["limitation"] = files.Count > 20
+                    ? "Only the 20 most recent run files are summarized; use history_path to inspect older local run files."
+                    : "Run history is summarized from the active profile's saved .run files."
+            };
+        }
+
+        return new Dictionary<string, object?>
+        {
+            ["ui_label"] = "Run History",
+            ["status"] = values.Count > 0 ? "partially_exposed" : "exposed_empty",
+            ["source"] = "SaveManager.Progress reflected run-history members",
+            ["entries"] = values,
+            ["limitation"] = values.Count > 0
+                ? "Run history is serialized from discovered progress members and capped for response size."
+                : "No run-history files or typed run-history members were found for the active profile."
+        };
+    }
+
+    private static Dictionary<string, object?> BuildRunHistoryEntry(FileInfo file)
+    {
+        var entry = new Dictionary<string, object?>
+        {
+            ["id"] = Path.GetFileNameWithoutExtension(file.Name),
+            ["file_name"] = file.Name,
+            ["size_bytes"] = file.Length,
+            ["last_write_time_utc"] = file.LastWriteTimeUtc
+        };
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(file.FullName));
+            var root = document.RootElement;
+
+            CopyJsonScalar(root, entry, "start_time");
+            CopyJsonScalar(root, entry, "run_time");
+            CopyJsonScalar(root, entry, "game_mode");
+            CopyJsonScalar(root, entry, "ascension");
+            CopyJsonScalar(root, entry, "win");
+            CopyJsonScalar(root, entry, "was_abandoned");
+            CopyJsonScalar(root, entry, "killed_by_encounter");
+            CopyJsonScalar(root, entry, "killed_by_event");
+            CopyJsonScalar(root, entry, "seed");
+            CopyJsonScalar(root, entry, "build_id");
+
+            if (root.TryGetProperty("acts", out var acts) && acts.ValueKind == JsonValueKind.Array)
+                entry["acts"] = acts.EnumerateArray().Select(GetJsonValue).ToList();
+
+            if (root.TryGetProperty("players", out var players) && players.ValueKind == JsonValueKind.Array)
+            {
+                entry["players"] = players.EnumerateArray().Select(player =>
+                {
+                    var playerEntry = new Dictionary<string, object?>();
+                    CopyJsonScalar(player, playerEntry, "id");
+                    CopyJsonScalar(player, playerEntry, "character");
+                    if (player.TryGetProperty("deck", out var deck) && deck.ValueKind == JsonValueKind.Array)
+                        playerEntry["deck_count"] = deck.GetArrayLength();
+                    if (player.TryGetProperty("relics", out var relics) && relics.ValueKind == JsonValueKind.Array)
+                        playerEntry["relic_count"] = relics.GetArrayLength();
+                    if (player.TryGetProperty("potions", out var potions) && potions.ValueKind == JsonValueKind.Array)
+                        playerEntry["potion_count"] = potions.GetArrayLength();
+                    return playerEntry;
+                }).ToList();
+            }
+
+            entry["map_point_count"] = CountMapPoints(root);
+        }
+        catch (Exception ex)
+        {
+            entry["parse_error"] = ex.Message;
+        }
+
+        return entry;
+    }
+
+    private static int CountMapPoints(JsonElement root)
+    {
+        if (!root.TryGetProperty("map_point_history", out var acts) || acts.ValueKind != JsonValueKind.Array)
+            return 0;
+
+        var count = 0;
+        foreach (var act in acts.EnumerateArray())
+        {
+            if (act.ValueKind == JsonValueKind.Array)
+                count += act.GetArrayLength();
+        }
+        return count;
+    }
+
+    private static void CopyJsonScalar(JsonElement source, Dictionary<string, object?> target, string propertyName)
+    {
+        if (source.TryGetProperty(propertyName, out var property))
+            target[propertyName] = GetJsonValue(property);
+    }
+
+    private static object? GetJsonValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number when element.TryGetInt64(out var longValue) => longValue,
+            JsonValueKind.Number when element.TryGetDouble(out var doubleValue) => doubleValue,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.ToString()
+        };
+    }
+
+    private static string? FindRunHistoryDirectory(int profileId)
+    {
+        var progressPath = GetProfileProgressPath(profileId);
+        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
+
+        foreach (var saveRoot in EnumerateSaveRoots())
+        {
+            var historyPath = Path.Combine(saveRoot, profileRoot, "saves", "history");
+            if (Directory.Exists(historyPath))
+                return historyPath;
+        }
+
+        return null;
+    }
+
+    private static string GetProfileRootFromProgressPath(string? progressPath, int profileId)
+    {
+        var normalized = progressPath?.Replace('\\', '/');
+        if (!string.IsNullOrWhiteSpace(normalized))
+        {
+            var marker = $"/profile{profileId}/";
+            var index = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0)
+                return normalized[..(index + marker.Length - 1)];
+
+            if (normalized.StartsWith($"profile{profileId}/", StringComparison.OrdinalIgnoreCase))
+                return $"profile{profileId}";
+            if (normalized.StartsWith($"modded/profile{profileId}/", StringComparison.OrdinalIgnoreCase))
+                return $"modded/profile{profileId}";
+        }
+
+        return $"profile{profileId}";
+    }
+
+    private static IEnumerable<string> EnumerateSaveRoots()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (string.IsNullOrWhiteSpace(appData))
+            yield break;
+
+        var steamRoot = Path.Combine(appData, "SlayTheSpire2", "steam");
+        if (!Directory.Exists(steamRoot))
+            yield break;
+
+        foreach (var accountRoot in Directory.GetDirectories(steamRoot))
+            yield return accountRoot;
+    }
+
+    private static string? GetProfileProgressPath(int profileId)
+    {
+        try { return ProgressSaveManager.GetProgressPathForProfile(profileId); }
+        catch { return null; }
+    }
+
+    private static string? ResolveProfileProgressPath(int profileId)
+    {
+        var progressPath = GetProfileProgressPath(profileId);
+        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
+
+        foreach (var saveRoot in EnumerateSaveRoots())
+        {
+            var absolutePath = Path.Combine(saveRoot, profileRoot, "saves", "progress.save");
+            if (File.Exists(absolutePath))
+                return absolutePath;
+        }
+
+        return progressPath;
+    }
+
+    private static object? ToJsonSafe(object? value, int depth, int maxItems)
+    {
+        if (value == null || depth > 4) return value?.ToString();
+        if (value is string or bool or byte or sbyte or short or ushort or int or uint or long or ulong or float or double or decimal)
+            return value;
+        if (value is Enum) return value.ToString();
+
+        var type = value.GetType();
+        var entryProperty = type.GetProperty("Entry", BindingFlags.Instance | BindingFlags.Public);
+        if (entryProperty?.GetValue(value) is string entry)
+            return entry;
+
+        if (value is IDictionary dictionary)
+        {
+            var result = new Dictionary<string, object?>();
+            var count = 0;
+            foreach (DictionaryEntry item in dictionary)
+            {
+                if (count++ >= maxItems) break;
+                result[item.Key?.ToString() ?? "null"] = ToJsonSafe(item.Value, depth + 1, maxItems);
+            }
+            return result;
+        }
+
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var result = new List<object?>();
+            var count = 0;
+            foreach (var item in enumerable)
+            {
+                if (count++ >= maxItems) break;
+                result.Add(ToJsonSafe(item, depth + 1, maxItems));
+            }
+            return result;
+        }
+
+        var obj = new Dictionary<string, object?>();
+        foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (property.GetIndexParameters().Length != 0)
+                continue;
+            try { obj[property.Name] = ToJsonSafe(property.GetValue(value), depth + 1, maxItems); }
+            catch { }
+        }
+        return obj.Count > 0 ? obj : value.ToString();
+    }
+}

--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text.Json;
+using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
 
@@ -60,6 +61,7 @@ public static partial class McpMod
         return new Dictionary<string, object?>
         {
             ["profile_id"] = saveManager.CurrentProfileId,
+            ["current_run"] = BuildCurrentRunContext(saveManager.CurrentProfileId),
             ["source"] = "SaveManager.Progress plus model metadata endpoints",
             ["sections"] = new Dictionary<string, object?>
             {
@@ -209,7 +211,7 @@ public static partial class McpMod
                 ["source"] = "Profile save history files",
                 ["history_path"] = historyDirectory,
                 ["entry_count"] = files.Count,
-                ["entries"] = files.Take(20).Select(BuildRunHistoryEntry).ToList(),
+                ["entries"] = files.Take(20).Select(file => BuildRunHistoryEntry(file, profileId)).ToList(),
                 ["progress_members"] = values.Count > 0 ? values : null,
                 ["limitation"] = files.Count > 20
                     ? "Only the 20 most recent run files are summarized; use history_path to inspect older local run files."
@@ -229,11 +231,14 @@ public static partial class McpMod
         };
     }
 
-    private static Dictionary<string, object?> BuildRunHistoryEntry(FileInfo file)
+    private static Dictionary<string, object?> BuildRunHistoryEntry(FileInfo file, int profileId)
     {
+        var profileRoot = GetProfileRootFromProgressPath(GetProfileProgressPath(profileId), profileId);
+        var saveScope = GetSaveScope(profileRoot);
         var entry = new Dictionary<string, object?>
         {
             ["id"] = Path.GetFileNameWithoutExtension(file.Name),
+            ["run_id"] = $"{saveScope}:profile{profileId}:{Path.GetFileNameWithoutExtension(file.Name)}",
             ["file_name"] = file.Name,
             ["size_bytes"] = file.Length,
             ["last_write_time_utc"] = file.LastWriteTimeUtc
@@ -283,6 +288,60 @@ public static partial class McpMod
         }
 
         return entry;
+    }
+
+    private static Dictionary<string, object?>? BuildCurrentRunContext(int profileId)
+    {
+        if (RunManager.Instance?.IsInProgress != true)
+            return null;
+
+        var profileRoot = GetProfileRootFromProgressPath(GetProfileProgressPath(profileId), profileId);
+        var saveScope = GetSaveScope(profileRoot);
+        var result = new Dictionary<string, object?>
+        {
+            ["is_in_progress"] = true,
+            ["profile_id"] = profileId,
+            ["save_scope"] = saveScope,
+            ["id_format"] = "{save_scope}:profile{profile_id}:{start_time}"
+        };
+
+        var currentRunPath = ResolveCurrentRunPath(profileId);
+        if (currentRunPath == null || !File.Exists(currentRunPath))
+        {
+            result["limitation"] = "Run is in progress, but current_run.save was not found yet.";
+            return result;
+        }
+
+        result["save_path"] = currentRunPath;
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(currentRunPath));
+            var root = document.RootElement;
+
+            CopyJsonScalar(root, result, "start_time");
+            CopyJsonScalar(root, result, "save_time");
+            CopyJsonScalar(root, result, "run_time");
+            CopyJsonScalar(root, result, "game_mode");
+            CopyJsonScalar(root, result, "ascension");
+            CopyJsonScalar(root, result, "current_act_index");
+            CopyJsonScalar(root, result, "schema_version");
+            CopyJsonScalar(root, result, "platform_type");
+
+            if (root.TryGetProperty("rng", out var rng)
+                && rng.ValueKind == JsonValueKind.Object
+                && rng.TryGetProperty("seed", out var seed))
+                result["seed"] = GetJsonValue(seed);
+
+            if (result.TryGetValue("start_time", out var startTime) && startTime != null)
+                result["run_id"] = $"{saveScope}:profile{profileId}:{startTime}";
+        }
+        catch (Exception ex)
+        {
+            result["parse_error"] = ex.Message;
+        }
+
+        return result;
     }
 
     private static int CountMapPoints(JsonElement root)
@@ -353,6 +412,13 @@ public static partial class McpMod
         return $"profile{profileId}";
     }
 
+    private static string GetSaveScope(string profileRoot)
+    {
+        return profileRoot.StartsWith("modded/", StringComparison.OrdinalIgnoreCase)
+            ? "modded"
+            : "vanilla";
+    }
+
     private static IEnumerable<string> EnumerateSaveRoots()
     {
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
@@ -386,6 +452,21 @@ public static partial class McpMod
         }
 
         return progressPath;
+    }
+
+    private static string? ResolveCurrentRunPath(int profileId)
+    {
+        var progressPath = GetProfileProgressPath(profileId);
+        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
+
+        foreach (var saveRoot in EnumerateSaveRoots())
+        {
+            var absolutePath = Path.Combine(saveRoot, profileRoot, "saves", "current_run.save");
+            if (File.Exists(absolutePath))
+                return absolutePath;
+        }
+
+        return null;
     }
 
     private static object? ToJsonSafe(object? value, int depth, int maxItems)

--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -14,12 +14,17 @@ namespace STS2_MCP;
 
 public static partial class McpMod
 {
+    private static readonly object _runHistoryMembersLock = new();
+    private static Type? _runHistoryMembersType;
+    private static MemberInfo[]? _runHistoryMembers;
+
     private static void HandleGetCompendium(HttpListenerResponse response)
     {
         try
         {
-            var dataTask = RunOnMainThread(BuildCompendium);
-            SendJson(response, dataTask.GetAwaiter().GetResult());
+            var snapshotTask = RunOnMainThread(BuildCompendiumSnapshot);
+            var snapshot = snapshotTask.GetAwaiter().GetResult();
+            SendJson(response, BuildCompendiumResponse(snapshot));
         }
         catch (Exception ex)
         {
@@ -29,10 +34,19 @@ public static partial class McpMod
 
     internal static object BuildCompendium()
     {
+        return BuildCompendiumResponse(BuildCompendiumSnapshot());
+    }
+
+    private static CompendiumSnapshot BuildCompendiumSnapshot()
+    {
         var progress = SaveManager.Instance?.Progress;
         var saveManager = SaveManager.Instance;
         if (progress == null || saveManager == null)
-            return new Dictionary<string, object?> { ["error"] = "No profile data available." };
+            return new CompendiumSnapshot { Error = "No profile data available." };
+
+        var profileId = saveManager.CurrentProfileId;
+        var progressPath = GetProfileProgressPath(profileId);
+        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
 
         var cardStats = progress.CardStats.Select(kv => new Dictionary<string, object?>
         {
@@ -56,12 +70,48 @@ public static partial class McpMod
             ["playtime"] = kv.Value.Playtime
         }).ToList();
 
-        var runHistory = BuildRunHistorySection(progress, saveManager.CurrentProfileId);
+        return new CompendiumSnapshot
+        {
+            ProfileId = profileId,
+            ProgressPath = progressPath,
+            ProfileRoot = profileRoot,
+            SaveScope = GetSaveScope(profileRoot),
+            IsRunInProgress = RunManager.Instance?.IsInProgress == true,
+            DiscoveredCards = progress.DiscoveredCards.Select(id => id.Entry).ToList(),
+            DiscoveredRelics = progress.DiscoveredRelics.Select(id => id.Entry).ToList(),
+            DiscoveredPotions = progress.DiscoveredPotions.Select(id => id.Entry).ToList(),
+            CardStats = cardStats,
+            CharacterStats = characterStats,
+            EncounterStats = BuildEncounterStats(progress),
+            EnemyStats = BuildEnemyStats(progress),
+            RunHistoryProgressMembers = BuildRunHistoryProgressMembers(progress),
+            GlobalStats = new Dictionary<string, object?>
+            {
+                ["total_playtime"] = progress.TotalPlaytime,
+                ["total_unlocks"] = progress.TotalUnlocks,
+                ["current_score"] = progress.CurrentScore,
+                ["floors_climbed"] = progress.FloorsClimbed,
+                ["architect_damage"] = progress.ArchitectDamage,
+                ["total_wins"] = progress.Wins,
+                ["total_losses"] = progress.Losses,
+                ["fastest_victory"] = progress.FastestVictory,
+                ["best_win_streak"] = progress.BestWinStreak,
+                ["number_of_runs"] = progress.NumberOfRuns
+            }
+        };
+    }
+
+    private static object BuildCompendiumResponse(CompendiumSnapshot snapshot)
+    {
+        if (snapshot.Error != null)
+            return new Dictionary<string, object?> { ["error"] = snapshot.Error };
+
+        var runHistory = BuildRunHistorySection(snapshot);
 
         return new Dictionary<string, object?>
         {
-            ["profile_id"] = saveManager.CurrentProfileId,
-            ["current_run"] = BuildCurrentRunContext(saveManager.CurrentProfileId),
+            ["profile_id"] = snapshot.ProfileId,
+            ["current_run"] = BuildCurrentRunContext(snapshot),
             ["source"] = "SaveManager.Progress plus model metadata endpoints",
             ["sections"] = new Dictionary<string, object?>
             {
@@ -72,8 +122,8 @@ public static partial class McpMod
                     ["source"] = "/api/v1/profile card_stats and discovered_cards",
                     ["detail_endpoint"] = "/api/v1/glossary/cards",
                     ["detail_endpoint_requires_run"] = true,
-                    ["discovered_ids"] = progress.DiscoveredCards.Select(id => id.Entry).ToList(),
-                    ["stats"] = cardStats
+                    ["discovered_ids"] = snapshot.DiscoveredCards,
+                    ["stats"] = snapshot.CardStats
                 },
                 ["relic_collection"] = new Dictionary<string, object?>
                 {
@@ -82,7 +132,7 @@ public static partial class McpMod
                     ["source"] = "/api/v1/profile discovered_relics",
                     ["detail_endpoint"] = "/api/v1/glossary/relics",
                     ["detail_endpoint_requires_run"] = true,
-                    ["discovered_ids"] = progress.DiscoveredRelics.Select(id => id.Entry).ToList(),
+                    ["discovered_ids"] = snapshot.DiscoveredRelics,
                     ["limitation"] = "Profile exposes discovered relic IDs; per-relic obtained counts are not exposed by a typed API here."
                 },
                 ["potion_lab"] = new Dictionary<string, object?>
@@ -92,7 +142,7 @@ public static partial class McpMod
                     ["source"] = "/api/v1/profile discovered_potions",
                     ["detail_endpoint"] = "/api/v1/glossary/potions",
                     ["detail_endpoint_requires_run"] = true,
-                    ["discovered_ids"] = progress.DiscoveredPotions.Select(id => id.Entry).ToList(),
+                    ["discovered_ids"] = snapshot.DiscoveredPotions,
                     ["limitation"] = "Profile exposes discovered potion IDs; per-potion lab UI metadata is not exposed by a typed API here."
                 },
                 ["bestiary"] = new Dictionary<string, object?>
@@ -101,8 +151,8 @@ public static partial class McpMod
                     ["status"] = "locked_in_ui",
                     ["source"] = "/api/v1/bestiary model metadata",
                     ["detail_endpoint"] = "/api/v1/bestiary",
-                    ["encounter_stats"] = BuildEncounterStats(progress),
-                    ["enemy_stats"] = BuildEnemyStats(progress),
+                    ["encounter_stats"] = snapshot.EncounterStats,
+                    ["enemy_stats"] = snapshot.EnemyStats,
                     ["limitation"] = "The current game UI labels Bestiary as future/locked; the endpoint exposes reflected model metadata and profile fight stats when available."
                 },
                 ["character_stats"] = new Dictionary<string, object?>
@@ -110,24 +160,31 @@ public static partial class McpMod
                     ["ui_label"] = "Character Stats",
                     ["status"] = "exposed",
                     ["source"] = "/api/v1/profile characters and global totals",
-                    ["characters"] = characterStats,
-                    ["global"] = new Dictionary<string, object?>
-                    {
-                        ["total_playtime"] = progress.TotalPlaytime,
-                        ["total_unlocks"] = progress.TotalUnlocks,
-                        ["current_score"] = progress.CurrentScore,
-                        ["floors_climbed"] = progress.FloorsClimbed,
-                        ["architect_damage"] = progress.ArchitectDamage,
-                        ["total_wins"] = progress.Wins,
-                        ["total_losses"] = progress.Losses,
-                        ["fastest_victory"] = progress.FastestVictory,
-                        ["best_win_streak"] = progress.BestWinStreak,
-                        ["number_of_runs"] = progress.NumberOfRuns
-                    }
+                    ["characters"] = snapshot.CharacterStats,
+                    ["global"] = snapshot.GlobalStats
                 },
                 ["run_history"] = runHistory
             }
         };
+    }
+
+    private sealed class CompendiumSnapshot
+    {
+        public string? Error { get; init; }
+        public int ProfileId { get; init; }
+        public string? ProgressPath { get; init; }
+        public string ProfileRoot { get; init; } = "";
+        public string SaveScope { get; init; } = "vanilla";
+        public bool IsRunInProgress { get; init; }
+        public List<string> DiscoveredCards { get; init; } = new();
+        public List<string> DiscoveredRelics { get; init; } = new();
+        public List<string> DiscoveredPotions { get; init; } = new();
+        public List<Dictionary<string, object?>> CardStats { get; init; } = new();
+        public List<Dictionary<string, object?>> CharacterStats { get; init; } = new();
+        public List<Dictionary<string, object?>> EncounterStats { get; init; } = new();
+        public List<Dictionary<string, object?>> EnemyStats { get; init; } = new();
+        public Dictionary<string, object?> RunHistoryProgressMembers { get; init; } = new();
+        public Dictionary<string, object?> GlobalStats { get; init; } = new();
     }
 
     private static List<Dictionary<string, object?>> BuildEncounterStats(dynamic progress)
@@ -171,16 +228,10 @@ public static partial class McpMod
         return entry;
     }
 
-    private static Dictionary<string, object?> BuildRunHistorySection(object progress, int profileId)
+    private static Dictionary<string, object?> BuildRunHistoryProgressMembers(object progress)
     {
-        var members = progress.GetType()
-            .GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            .Where(member => member.Name.Contains("RunHistory", StringComparison.OrdinalIgnoreCase)
-                || member.Name.Contains("RunHistories", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
         var values = new Dictionary<string, object?>();
-        foreach (var member in members)
+        foreach (var member in GetRunHistoryMembers(progress.GetType()))
         {
             try
             {
@@ -195,8 +246,30 @@ public static partial class McpMod
             }
             catch { }
         }
+        return values;
+    }
 
-        var historyDirectory = FindRunHistoryDirectory(profileId);
+    private static MemberInfo[] GetRunHistoryMembers(Type progressType)
+    {
+        lock (_runHistoryMembersLock)
+        {
+            if (_runHistoryMembersType == progressType && _runHistoryMembers != null)
+                return _runHistoryMembers;
+
+            _runHistoryMembersType = progressType;
+            _runHistoryMembers = progressType
+                .GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(member => member.Name.Contains("RunHistory", StringComparison.OrdinalIgnoreCase)
+                    || member.Name.Contains("RunHistories", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            return _runHistoryMembers;
+        }
+    }
+
+    private static Dictionary<string, object?> BuildRunHistorySection(CompendiumSnapshot snapshot)
+    {
+        var values = snapshot.RunHistoryProgressMembers;
+        var historyDirectory = FindRunHistoryDirectory(snapshot.ProfileRoot);
         if (historyDirectory != null)
         {
             var files = Directory.GetFiles(historyDirectory, "*.run")
@@ -211,7 +284,7 @@ public static partial class McpMod
                 ["source"] = "Profile save history files",
                 ["history_path"] = historyDirectory,
                 ["entry_count"] = files.Count,
-                ["entries"] = files.Take(20).Select(file => BuildRunHistoryEntry(file, profileId)).ToList(),
+                ["entries"] = files.Take(20).Select(file => BuildRunHistoryEntry(file, snapshot.ProfileId, snapshot.SaveScope)).ToList(),
                 ["progress_members"] = values.Count > 0 ? values : null,
                 ["limitation"] = files.Count > 20
                     ? "Only the 20 most recent run files are summarized; use history_path to inspect older local run files."
@@ -231,10 +304,8 @@ public static partial class McpMod
         };
     }
 
-    private static Dictionary<string, object?> BuildRunHistoryEntry(FileInfo file, int profileId)
+    private static Dictionary<string, object?> BuildRunHistoryEntry(FileInfo file, int profileId, string saveScope)
     {
-        var profileRoot = GetProfileRootFromProgressPath(GetProfileProgressPath(profileId), profileId);
-        var saveScope = GetSaveScope(profileRoot);
         var entry = new Dictionary<string, object?>
         {
             ["id"] = Path.GetFileNameWithoutExtension(file.Name),
@@ -246,7 +317,8 @@ public static partial class McpMod
 
         try
         {
-            using var document = JsonDocument.Parse(File.ReadAllText(file.FullName));
+            using var stream = file.OpenRead();
+            using var document = JsonDocument.Parse(stream);
             var root = document.RootElement;
 
             CopyJsonScalar(root, entry, "start_time");
@@ -290,22 +362,20 @@ public static partial class McpMod
         return entry;
     }
 
-    private static Dictionary<string, object?>? BuildCurrentRunContext(int profileId)
+    private static Dictionary<string, object?>? BuildCurrentRunContext(CompendiumSnapshot snapshot)
     {
-        if (RunManager.Instance?.IsInProgress != true)
+        if (!snapshot.IsRunInProgress)
             return null;
 
-        var profileRoot = GetProfileRootFromProgressPath(GetProfileProgressPath(profileId), profileId);
-        var saveScope = GetSaveScope(profileRoot);
         var result = new Dictionary<string, object?>
         {
             ["is_in_progress"] = true,
-            ["profile_id"] = profileId,
-            ["save_scope"] = saveScope,
+            ["profile_id"] = snapshot.ProfileId,
+            ["save_scope"] = snapshot.SaveScope,
             ["id_format"] = "{save_scope}:profile{profile_id}:{start_time}"
         };
 
-        var currentRunPath = ResolveCurrentRunPath(profileId);
+        var currentRunPath = ResolveCurrentRunPath(snapshot.ProfileRoot);
         if (currentRunPath == null || !File.Exists(currentRunPath))
         {
             result["limitation"] = "Run is in progress, but current_run.save was not found yet.";
@@ -316,7 +386,8 @@ public static partial class McpMod
 
         try
         {
-            using var document = JsonDocument.Parse(File.ReadAllText(currentRunPath));
+            using var stream = File.OpenRead(currentRunPath);
+            using var document = JsonDocument.Parse(stream);
             var root = document.RootElement;
 
             CopyJsonScalar(root, result, "start_time");
@@ -334,7 +405,7 @@ public static partial class McpMod
                 result["seed"] = GetJsonValue(seed);
 
             if (result.TryGetValue("start_time", out var startTime) && startTime != null)
-                result["run_id"] = $"{saveScope}:profile{profileId}:{startTime}";
+                result["run_id"] = $"{snapshot.SaveScope}:profile{snapshot.ProfileId}:{startTime}";
         }
         catch (Exception ex)
         {
@@ -378,11 +449,8 @@ public static partial class McpMod
         };
     }
 
-    private static string? FindRunHistoryDirectory(int profileId)
+    private static string? FindRunHistoryDirectory(string profileRoot)
     {
-        var progressPath = GetProfileProgressPath(profileId);
-        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
-
         foreach (var saveRoot in EnumerateSaveRoots())
         {
             var historyPath = Path.Combine(saveRoot, profileRoot, "saves", "history");
@@ -454,11 +522,8 @@ public static partial class McpMod
         return progressPath;
     }
 
-    private static string? ResolveCurrentRunPath(int profileId)
+    private static string? ResolveCurrentRunPath(string profileRoot)
     {
-        var progressPath = GetProfileProgressPath(profileId);
-        var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
-
         foreach (var saveRoot in EnumerateSaveRoots())
         {
             var absolutePath = Path.Combine(saveRoot, profileRoot, "saves", "current_run.save");

--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -113,7 +113,7 @@ public static partial class McpMod
         {
             ["profile_id"] = snapshot.ProfileId,
             ["current_run"] = BuildCurrentRunContext(snapshot),
-            ["source"] = "SaveManager.Progress plus model metadata endpoints",
+            ["source"] = "SaveManager.Progress and active-profile save files",
             ["sections"] = new Dictionary<string, object?>
             {
                 ["card_library"] = new Dictionary<string, object?>
@@ -121,8 +121,7 @@ public static partial class McpMod
                     ["ui_label"] = "Card Library",
                     ["status"] = "exposed",
                     ["source"] = "/api/v1/profile card_stats and discovered_cards",
-                    ["detail_endpoint"] = "/api/v1/glossary/cards",
-                    ["detail_endpoint_requires_run"] = true,
+                    ["metadata_limitation"] = "This endpoint exposes profile-level discovery and aggregate card stats. Card rules text remains available through game state when cards are visible in a run.",
                     ["discovered_ids"] = snapshot.DiscoveredCards,
                     ["stats"] = snapshot.CardStats
                 },
@@ -131,30 +130,25 @@ public static partial class McpMod
                     ["ui_label"] = "Relic Collection",
                     ["status"] = "partially_exposed",
                     ["source"] = "/api/v1/profile discovered_relics",
-                    ["detail_endpoint"] = "/api/v1/glossary/relics",
-                    ["detail_endpoint_requires_run"] = true,
                     ["discovered_ids"] = snapshot.DiscoveredRelics,
-                    ["limitation"] = "Profile exposes discovered relic IDs; per-relic obtained counts are not exposed by a typed API here."
+                    ["limitation"] = "Profile exposes discovered relic IDs; per-relic descriptions and obtained counts are not exposed by a typed profile API here."
                 },
                 ["potion_lab"] = new Dictionary<string, object?>
                 {
                     ["ui_label"] = "Potion Lab",
                     ["status"] = "partially_exposed",
                     ["source"] = "/api/v1/profile discovered_potions",
-                    ["detail_endpoint"] = "/api/v1/glossary/potions",
-                    ["detail_endpoint_requires_run"] = true,
                     ["discovered_ids"] = snapshot.DiscoveredPotions,
-                    ["limitation"] = "Profile exposes discovered potion IDs; per-potion lab UI metadata is not exposed by a typed API here."
+                    ["limitation"] = "Profile exposes discovered potion IDs; per-potion rules text and lab UI metadata are not exposed by a typed profile API here."
                 },
                 ["bestiary"] = new Dictionary<string, object?>
                 {
                     ["ui_label"] = "Bestiary",
                     ["status"] = "locked_in_ui",
-                    ["source"] = "/api/v1/bestiary model metadata",
-                    ["detail_endpoint"] = "/api/v1/bestiary",
+                    ["source"] = "SaveManager.Progress encounter and enemy fight stats",
                     ["encounter_stats"] = snapshot.EncounterStats,
                     ["enemy_stats"] = snapshot.EnemyStats,
-                    ["limitation"] = "The current game UI labels Bestiary as future/locked; the endpoint exposes reflected model metadata and profile fight stats when available."
+                    ["limitation"] = "The current game UI labels Bestiary as future/locked; this endpoint exposes profile fight stats when available, not a full enemy metadata catalog."
                 },
                 ["character_stats"] = new Dictionary<string, object?>
                 {

--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -270,7 +270,7 @@ public static partial class McpMod
     private static Dictionary<string, object?> BuildRunHistorySection(CompendiumSnapshot snapshot)
     {
         var values = snapshot.RunHistoryProgressMembers;
-        var historyDirectory = FindRunHistoryDirectory(snapshot.ProfileRoot);
+        var historyDirectory = FindRunHistoryDirectory(snapshot);
         if (historyDirectory != null)
         {
             var files = Directory.GetFiles(historyDirectory, "*.run")
@@ -376,7 +376,7 @@ public static partial class McpMod
             ["id_format"] = "{save_scope}:profile{profile_id}:{start_time}"
         };
 
-        var currentRunPath = ResolveCurrentRunPath(snapshot.ProfileRoot);
+        var currentRunPath = ResolveCurrentRunPath(snapshot);
         if (currentRunPath == null || !File.Exists(currentRunPath))
         {
             result["limitation"] = "Run is in progress, but current_run.save was not found yet.";
@@ -450,11 +450,19 @@ public static partial class McpMod
         };
     }
 
-    private static string? FindRunHistoryDirectory(string profileRoot)
+    private static string? FindRunHistoryDirectory(CompendiumSnapshot snapshot)
     {
+        var saveDirectory = GetSaveDirectoryFromProgressPath(snapshot.ProgressPath);
+        if (saveDirectory != null)
+        {
+            var historyPath = Path.Combine(saveDirectory, "history");
+            if (Directory.Exists(historyPath))
+                return historyPath;
+        }
+
         foreach (var saveRoot in EnumerateSaveRoots())
         {
-            var historyPath = Path.Combine(saveRoot, profileRoot, "saves", "history");
+            var historyPath = Path.Combine(saveRoot, snapshot.ProfileRoot, "saves", "history");
             if (Directory.Exists(historyPath))
                 return historyPath;
         }
@@ -467,15 +475,16 @@ public static partial class McpMod
         var normalized = progressPath?.Replace('\\', '/');
         if (!string.IsNullOrWhiteSpace(normalized))
         {
-            var marker = $"/profile{profileId}/";
-            var index = normalized.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-            if (index >= 0)
-                return normalized[..(index + marker.Length - 1)];
-
-            if (normalized.StartsWith($"profile{profileId}/", StringComparison.OrdinalIgnoreCase))
-                return $"profile{profileId}";
-            if (normalized.StartsWith($"modded/profile{profileId}/", StringComparison.OrdinalIgnoreCase))
+            var moddedProfile = $"modded/profile{profileId}";
+            if (normalized.Contains($"{moddedProfile}/", StringComparison.OrdinalIgnoreCase)
+                || normalized.Equals(moddedProfile, StringComparison.OrdinalIgnoreCase))
                 return $"modded/profile{profileId}";
+
+            var profile = $"profile{profileId}";
+            if (normalized.Contains($"/{profile}/", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith($"{profile}/", StringComparison.OrdinalIgnoreCase)
+                || normalized.Equals(profile, StringComparison.OrdinalIgnoreCase))
+                return $"profile{profileId}";
         }
 
         return $"profile{profileId}";
@@ -490,26 +499,58 @@ public static partial class McpMod
 
     private static IEnumerable<string> EnumerateSaveRoots()
     {
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        if (string.IsNullOrWhiteSpace(appData))
-            yield break;
+        var yielded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var steamRoots = EnumerateSteamDataRoots().ToList();
 
-        var steamRoot = Path.Combine(appData, "SlayTheSpire2", "steam");
-        if (!Directory.Exists(steamRoot))
-            yield break;
-
-        var activeSteamSaveRoot = GetActiveSteamSaveRoot(steamRoot);
-        if (activeSteamSaveRoot != null)
+        var activeSteamId = GetActiveSteamId();
+        if (!string.IsNullOrWhiteSpace(activeSteamId))
         {
-            yield return activeSteamSaveRoot;
-            yield break;
+            foreach (var steamRoot in steamRoots)
+            {
+                var accountRoot = Path.Combine(steamRoot, activeSteamId);
+                if (Directory.Exists(accountRoot) && yielded.Add(accountRoot))
+                    yield return accountRoot;
+            }
         }
 
-        foreach (var accountRoot in Directory.GetDirectories(steamRoot))
-            yield return accountRoot;
+        if (yielded.Count > 0)
+            yield break;
+
+        foreach (var steamRoot in steamRoots)
+        {
+            foreach (var accountRoot in Directory.GetDirectories(steamRoot))
+            {
+                if (yielded.Add(accountRoot))
+                    yield return accountRoot;
+            }
+        }
     }
 
-    private static string? GetActiveSteamSaveRoot(string steamRoot)
+    private static IEnumerable<string> EnumerateSteamDataRoots()
+    {
+        var candidates = new List<string?>();
+
+        candidates.Add(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
+        candidates.Add(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
+        candidates.Add(Environment.GetEnvironmentVariable("XDG_DATA_HOME"));
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrWhiteSpace(home))
+            candidates.Add(Path.Combine(home, ".local", "share"));
+
+        var yielded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var root in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                continue;
+
+            var steamRoot = Path.Combine(root, "SlayTheSpire2", "steam");
+            if (Directory.Exists(steamRoot) && yielded.Add(steamRoot))
+                yield return steamRoot;
+        }
+    }
+
+    private static string? GetActiveSteamId()
     {
         try
         {
@@ -522,8 +563,7 @@ public static partial class McpMod
             if (string.IsNullOrWhiteSpace(steamId) || steamId == "0")
                 return null;
 
-            var accountRoot = Path.Combine(steamRoot, steamId);
-            return Directory.Exists(accountRoot) ? accountRoot : null;
+            return steamId;
         }
         catch
         {
@@ -540,6 +580,9 @@ public static partial class McpMod
     private static string? ResolveProfileProgressPath(int profileId)
     {
         var progressPath = GetProfileProgressPath(profileId);
+        if (!string.IsNullOrWhiteSpace(progressPath) && Path.IsPathRooted(progressPath))
+            return progressPath;
+
         var profileRoot = GetProfileRootFromProgressPath(progressPath, profileId);
 
         foreach (var saveRoot in EnumerateSaveRoots())
@@ -552,16 +595,35 @@ public static partial class McpMod
         return progressPath;
     }
 
-    private static string? ResolveCurrentRunPath(string profileRoot)
+    private static string? ResolveCurrentRunPath(CompendiumSnapshot snapshot)
     {
+        var saveDirectory = GetSaveDirectoryFromProgressPath(snapshot.ProgressPath);
+        if (saveDirectory != null)
+        {
+            var currentRunPath = Path.Combine(saveDirectory, "current_run.save");
+            if (File.Exists(currentRunPath))
+                return currentRunPath;
+        }
+
         foreach (var saveRoot in EnumerateSaveRoots())
         {
-            var absolutePath = Path.Combine(saveRoot, profileRoot, "saves", "current_run.save");
+            var absolutePath = Path.Combine(saveRoot, snapshot.ProfileRoot, "saves", "current_run.save");
             if (File.Exists(absolutePath))
                 return absolutePath;
         }
 
         return null;
+    }
+
+    private static string? GetSaveDirectoryFromProgressPath(string? progressPath)
+    {
+        if (string.IsNullOrWhiteSpace(progressPath) || !Path.IsPathRooted(progressPath))
+            return null;
+
+        var saveDirectory = Path.GetDirectoryName(progressPath);
+        return !string.IsNullOrWhiteSpace(saveDirectory) && Directory.Exists(saveDirectory)
+            ? saveDirectory
+            : null;
     }
 
     private static object? ToJsonSafe(object? value, int depth, int maxItems)

--- a/McpMod.Compendium.cs
+++ b/McpMod.Compendium.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text.Json;
+using MegaCrit.Sts2.Core.Platform.Steam;
 using MegaCrit.Sts2.Core.Runs;
 using MegaCrit.Sts2.Core.Saves;
 using MegaCrit.Sts2.Core.Saves.Managers;
@@ -497,8 +498,37 @@ public static partial class McpMod
         if (!Directory.Exists(steamRoot))
             yield break;
 
+        var activeSteamSaveRoot = GetActiveSteamSaveRoot(steamRoot);
+        if (activeSteamSaveRoot != null)
+        {
+            yield return activeSteamSaveRoot;
+            yield break;
+        }
+
         foreach (var accountRoot in Directory.GetDirectories(steamRoot))
             yield return accountRoot;
+    }
+
+    private static string? GetActiveSteamSaveRoot(string steamRoot)
+    {
+        try
+        {
+            if (!SteamInitializer.Initialized)
+                return null;
+
+            var steamUtil = typeof(SteamInitializer).Assembly.GetType("MegaCrit.Sts2.Core.Platform.Steam.SteamUtil");
+            var getSteamId = steamUtil?.GetMethod("GetSteamID64", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            var steamId = getSteamId?.Invoke(null, null)?.ToString();
+            if (string.IsNullOrWhiteSpace(steamId) || steamId == "0")
+                return null;
+
+            var accountRoot = Path.Combine(steamRoot, steamId);
+            return Directory.Exists(accountRoot) ? accountRoot : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static string? GetProfileProgressPath(int profileId)

--- a/McpMod.Helpers.cs
+++ b/McpMod.Helpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Godot;
@@ -19,6 +20,36 @@ public static partial class McpMod
     {
         try { return StripRichTextTags(card.GetDescriptionForPile(pile)).Replace("\n", " "); }
         catch { return SafeGetText(() => card.Description)?.Replace("\n", " "); }
+    }
+
+    private static CardModel? SafeBuildUpgradedCardPreview(CardModel card)
+    {
+        if (!card.IsUpgradable)
+            return null;
+
+        try
+        {
+            var preview = card.IsMutable
+                ? (CardModel)card.MutableClone()
+                : card.ToMutable();
+            preview.UpgradeInternal();
+            return preview;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? SafeGetCardUpgradePreviewDescription(CardModel card, PileType pile = PileType.Hand)
+    {
+        var preview = SafeBuildUpgradedCardPreview(card);
+        if (preview != null)
+            return SafeGetCardDescription(preview, pile);
+
+        return card.IsUpgradable
+            ? SafeGetText(() => card.GetDescriptionForUpgradePreview())?.Replace("\n", " ")
+            : null;
     }
 
     internal static string? SafeGetText(Func<object?> getter)

--- a/McpMod.Profile.cs
+++ b/McpMod.Profile.cs
@@ -98,8 +98,10 @@ public static partial class McpMod
             try
             {
                 var path = ProgressSaveManager.GetProgressPathForProfile(i);
-                profileData["has_data"] = File.Exists(path);
+                var resolvedPath = ResolveProfileProgressPath(i);
+                profileData["has_data"] = resolvedPath != null && File.Exists(resolvedPath);
                 profileData["path"] = path;
+                profileData["resolved_path"] = resolvedPath;
             }
             catch
             {

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -963,12 +963,20 @@ public static partial class McpMod
             info["expected_player_count"] = lobby.Run?.Players?.Count ?? 0;
             info["connected_player_count"] = lobby.ConnectedPlayerIds?.Count ?? 0;
 
-            // IsAboutToBeginGame == "no players still in handshake AND every connected player is ready".
-            // It's the literal trigger for the host's TryBeginRun, so it doubles as both "all_ready" (matches
-            // the StartRunLobby semantic of 'every joined player is ready') and "is_about_to_begin".
+            // LoadRunLobby no longer exposes IsAboutToBeginGame in the public game API,
+            // so derive the same readiness summary from connected players and ready flags.
             // Without these fields, FormatLobbyMarkdown printed "All ready: false" unconditionally for load lobbies.
             bool aboutToBegin = false;
-            try { aboutToBegin = lobby.IsAboutToBeginGame(); } catch { }
+            try
+            {
+                var runPlayers = lobby.Run?.Players;
+                var connectedPlayerIds = lobby.ConnectedPlayerIds;
+                aboutToBegin = runPlayers != null
+                    && connectedPlayerIds != null
+                    && runPlayers.Count > 0
+                    && runPlayers.All(player => connectedPlayerIds.Contains(player.NetId) && lobby.IsPlayerReady(player.NetId));
+            }
+            catch { }
             info["all_ready"] = aboutToBegin;
             info["is_about_to_begin"] = aboutToBegin;
 

--- a/McpMod.Wiki.cs
+++ b/McpMod.Wiki.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Saves;
+
+namespace STS2_MCP;
+
+public static partial class McpMod
+{
+    private const int DefaultWikiSearchLimit = 10;
+    private const int MaxWikiSearchLimit = 50;
+
+    private static void HandleGetWiki(HttpListenerRequest request, HttpListenerResponse response)
+    {
+        var query = request.QueryString["query"] ?? request.QueryString["q"] ?? "";
+        var itemType = request.QueryString["type"] ?? request.QueryString["item_type"] ?? "all";
+        var limit = ParseWikiLimit(request.QueryString["limit"]);
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            SendError(response, 400, "query is required; wiki search does not return the full profile catalog.");
+            return;
+        }
+
+        try
+        {
+            var dataTask = RunOnMainThread(() => BuildWikiSearch(query, itemType, limit));
+            SendJson(response, dataTask.GetAwaiter().GetResult());
+        }
+        catch (Exception ex)
+        {
+            SendError(response, 500, $"Failed to search wiki: {ex.Message}");
+        }
+    }
+
+    internal static object SearchWiki(string query, string itemType = "all", int? limit = null)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return Error("query is required; wiki search does not return the full profile catalog.");
+
+        return BuildWikiSearch(query, itemType, NormalizeWikiLimit(limit ?? DefaultWikiSearchLimit));
+    }
+
+    private static Dictionary<string, object?> BuildWikiSearch(string query, string itemType, int limit)
+    {
+        var progress = SaveManager.Instance?.Progress;
+        var saveManager = SaveManager.Instance;
+        if (progress == null || saveManager == null)
+            return Error("No profile data available.");
+
+        var normalizedItemType = NormalizeWikiItemType(itemType);
+        if (normalizedItemType == null)
+            return Error("item_type must be one of: all, card, relic.");
+
+        var discoveredCards = progress.DiscoveredCards
+            .Select(id => id.Entry)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var discoveredRelics = progress.DiscoveredRelics
+            .Select(id => id.Entry)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var candidates = new List<WikiCandidate>();
+        if (normalizedItemType is "all" or "card")
+            candidates.AddRange(BuildCardWikiCandidates(discoveredCards));
+        if (normalizedItemType is "all" or "relic")
+            candidates.AddRange(BuildRelicWikiCandidates(discoveredRelics));
+
+        var matches = candidates
+            .Select(candidate => new
+            {
+                Candidate = candidate,
+                Score = ScoreWikiCandidate(query, candidate)
+            })
+            .Where(match => match.Score > 0)
+            .OrderByDescending(match => match.Score)
+            .ThenBy(match => match.Candidate.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(limit)
+            .Select(match => BuildWikiResult(match.Candidate, match.Score))
+            .ToList();
+
+        return new Dictionary<string, object?>
+        {
+            ["status"] = "ok",
+            ["profile_id"] = saveManager.CurrentProfileId,
+            ["query"] = query,
+            ["item_type"] = normalizedItemType,
+            ["limit"] = limit,
+            ["scope"] = "active_profile_discovered_cards_and_relics",
+            ["selection_policy"] = "Searches only cards and relics discovered by the active profile, then returns the best fuzzy matches instead of exposing the full catalog.",
+            ["counts"] = new Dictionary<string, object?>
+            {
+                ["discovered_cards"] = discoveredCards.Count,
+                ["discovered_relics"] = discoveredRelics.Count,
+                ["searched"] = candidates.Count,
+                ["returned"] = matches.Count
+            },
+            ["results"] = matches
+        };
+    }
+
+    private static int ParseWikiLimit(string? rawLimit)
+    {
+        if (!int.TryParse(rawLimit, out var limit))
+            return DefaultWikiSearchLimit;
+        return NormalizeWikiLimit(limit);
+    }
+
+    private static int NormalizeWikiLimit(int limit)
+        => Math.Clamp(limit, 1, MaxWikiSearchLimit);
+
+    private static string? NormalizeWikiItemType(string? itemType)
+    {
+        var value = (itemType ?? "all").Trim().ToLowerInvariant();
+        return value switch
+        {
+            "" or "all" or "any" => "all",
+            "card" or "cards" => "card",
+            "relic" or "relics" => "relic",
+            _ => null
+        };
+    }
+
+    private static IEnumerable<WikiCandidate> BuildCardWikiCandidates(HashSet<string> discoveredIds)
+    {
+        var byId = new Dictionary<string, WikiCandidate>(StringComparer.OrdinalIgnoreCase);
+        foreach (var type in GetLoadableTypes(typeof(CardModel).Assembly))
+        {
+            if (type == null || type.IsAbstract || !typeof(CardModel).IsAssignableFrom(type))
+                continue;
+
+            var card = TryCreateModel<CardModel>(type);
+            var id = SafeGetText(() => card?.Id.Entry);
+            if (card == null || string.IsNullOrWhiteSpace(id) || !discoveredIds.Contains(id))
+                continue;
+
+            byId.TryAdd(id, new WikiCandidate(
+                Kind: "card",
+                Id: id,
+                Name: SafeGetText(() => card.Title) ?? id,
+                SearchText: BuildWikiSearchText("card", id, SafeGetText(() => card.Title), SafeGetText(() => card.Type), SafeGetText(() => card.Rarity)),
+                Card: card,
+                Relic: null));
+        }
+
+        return byId.Values;
+    }
+
+    private static IEnumerable<WikiCandidate> BuildRelicWikiCandidates(HashSet<string> discoveredIds)
+    {
+        var byId = new Dictionary<string, WikiCandidate>(StringComparer.OrdinalIgnoreCase);
+        foreach (var type in GetLoadableTypes(typeof(RelicModel).Assembly))
+        {
+            if (type == null || type.IsAbstract || !typeof(RelicModel).IsAssignableFrom(type))
+                continue;
+
+            var relic = TryCreateModel<RelicModel>(type);
+            var id = SafeGetText(() => relic?.Id.Entry);
+            if (relic == null || string.IsNullOrWhiteSpace(id) || !discoveredIds.Contains(id))
+                continue;
+
+            byId.TryAdd(id, new WikiCandidate(
+                Kind: "relic",
+                Id: id,
+                Name: SafeGetText(() => relic.Title) ?? id,
+                SearchText: BuildWikiSearchText("relic", id, SafeGetText(() => relic.Title), SafeGetText(() => relic.Rarity)),
+                Card: null,
+                Relic: relic));
+        }
+
+        return byId.Values;
+    }
+
+    private static IEnumerable<Type?> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            return ex.Types.Where(type => type != null);
+        }
+    }
+
+    private static T? TryCreateModel<T>(Type type) where T : class
+    {
+        try { return Activator.CreateInstance(type, nonPublic: true) as T; }
+        catch { return null; }
+    }
+
+    private static Dictionary<string, object?> BuildWikiResult(WikiCandidate candidate, double score)
+    {
+        if (candidate.Card != null)
+            return BuildWikiCardResult(candidate, score);
+        if (candidate.Relic != null)
+            return BuildWikiRelicResult(candidate, score);
+
+        return new Dictionary<string, object?>
+        {
+            ["item_type"] = candidate.Kind,
+            ["id"] = candidate.Id,
+            ["name"] = candidate.Name,
+            ["score"] = Math.Round(score, 3)
+        };
+    }
+
+    private static Dictionary<string, object?> BuildWikiCardResult(WikiCandidate candidate, double score)
+    {
+        var card = candidate.Card!;
+        var upgraded = SafeBuildUpgradedCardPreview(card);
+        var upgradedVariant = upgraded != null
+            ? BuildWikiCardVariant(upgraded, "upgraded")
+            : card.IsUpgradable
+                ? new Dictionary<string, object?>
+                {
+                    ["variant"] = "upgraded",
+                    ["description"] = SafeGetCardUpgradePreviewDescription(card),
+                    ["preview_available"] = false
+                }
+                : null;
+
+        var result = new Dictionary<string, object?>
+        {
+            ["item_type"] = "card",
+            ["id"] = candidate.Id,
+            ["name"] = candidate.Name,
+            ["score"] = Math.Round(score, 3),
+            ["rarity"] = SafeGetText(() => card.Rarity),
+            ["type"] = SafeGetText(() => card.Type),
+            ["is_upgradable"] = card.IsUpgradable,
+            ["current_upgrade_level"] = card.CurrentUpgradeLevel,
+            ["max_upgrade_level"] = card.MaxUpgradeLevel,
+            ["base"] = BuildWikiCardVariant(card, "base"),
+            ["upgraded"] = upgradedVariant
+        };
+
+        return result;
+    }
+
+    private static Dictionary<string, object?> BuildWikiCardVariant(CardModel card, string variant)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["variant"] = variant,
+            ["id"] = SafeGetText(() => card.Id.Entry),
+            ["name"] = SafeGetText(() => card.Title),
+            ["type"] = SafeGetText(() => card.Type),
+            ["rarity"] = SafeGetText(() => card.Rarity),
+            ["cost"] = GetCostDisplay(card),
+            ["star_cost"] = GetStarCostDisplay(card),
+            ["description"] = SafeGetCardDescription(card),
+            ["is_upgraded"] = card.IsUpgraded,
+            ["is_upgradable"] = card.IsUpgradable,
+            ["current_upgrade_level"] = card.CurrentUpgradeLevel,
+            ["max_upgrade_level"] = card.MaxUpgradeLevel,
+            ["keywords"] = BuildHoverTips(card.HoverTips)
+        };
+    }
+
+    private static Dictionary<string, object?> BuildWikiRelicResult(WikiCandidate candidate, double score)
+    {
+        var relic = candidate.Relic!;
+        return new Dictionary<string, object?>
+        {
+            ["item_type"] = "relic",
+            ["id"] = candidate.Id,
+            ["name"] = candidate.Name,
+            ["score"] = Math.Round(score, 3),
+            ["rarity"] = SafeGetText(() => relic.Rarity),
+            ["description"] = SafeGetText(() => relic.DynamicDescription),
+            ["keywords"] = BuildHoverTips(relic.HoverTipsExcludingRelic)
+        };
+    }
+
+    private static string BuildWikiSearchText(params string?[] values)
+        => string.Join(" ", values.Where(value => !string.IsNullOrWhiteSpace(value)));
+
+    private static double ScoreWikiCandidate(string query, WikiCandidate candidate)
+    {
+        var queryNormalized = NormalizeSearchText(query);
+        var candidateNormalized = NormalizeSearchText(candidate.SearchText);
+        if (string.IsNullOrWhiteSpace(queryNormalized) || string.IsNullOrWhiteSpace(candidateNormalized))
+            return 0;
+
+        var queryCompact = CompactSearchText(queryNormalized);
+        var candidateCompact = CompactSearchText(candidateNormalized);
+        var nameCompact = CompactSearchText(candidate.Name);
+        var idCompact = CompactSearchText(candidate.Id);
+
+        if (queryCompact.Equals(nameCompact, StringComparison.OrdinalIgnoreCase)
+            || queryCompact.Equals(idCompact, StringComparison.OrdinalIgnoreCase))
+            return 1000;
+
+        if (nameCompact.Contains(queryCompact, StringComparison.OrdinalIgnoreCase)
+            || idCompact.Contains(queryCompact, StringComparison.OrdinalIgnoreCase))
+            return 850;
+
+        var queryTokens = TokenizeSearchText(queryNormalized);
+        var candidateTokens = TokenizeSearchText(candidateNormalized);
+        if (queryTokens.Count == 0 || candidateTokens.Count == 0)
+            return 0;
+
+        double total = 0;
+        var strongMatches = 0;
+        foreach (var queryToken in queryTokens)
+        {
+            var best = candidateTokens.Max(candidateToken => TokenSimilarity(queryToken, candidateToken));
+            total += best;
+            if (best >= 0.72)
+                strongMatches++;
+        }
+
+        var average = total / queryTokens.Count;
+        var score = average * 700;
+        if (strongMatches > 0)
+            score += strongMatches * 35;
+
+        return score >= 300 ? score : 0;
+    }
+
+    private static string NormalizeSearchText(string value)
+    {
+        var sb = new StringBuilder(value.Length);
+        var lastWasSpace = true;
+        foreach (var ch in value.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(ch);
+                lastWasSpace = false;
+            }
+            else if (!lastWasSpace)
+            {
+                sb.Append(' ');
+                lastWasSpace = true;
+            }
+        }
+
+        return sb.ToString().Trim();
+    }
+
+    private static string CompactSearchText(string value)
+        => NormalizeSearchText(value).Replace(" ", "", StringComparison.Ordinal);
+
+    private static List<string> TokenizeSearchText(string value)
+        => NormalizeSearchText(value)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+    private static double TokenSimilarity(string queryToken, string candidateToken)
+    {
+        if (queryToken.Equals(candidateToken, StringComparison.OrdinalIgnoreCase))
+            return 1.0;
+
+        if (candidateToken.Contains(queryToken, StringComparison.OrdinalIgnoreCase)
+            || queryToken.Contains(candidateToken, StringComparison.OrdinalIgnoreCase))
+            return 0.88;
+
+        var distance = LevenshteinDistance(queryToken, candidateToken);
+        var maxLength = Math.Max(queryToken.Length, candidateToken.Length);
+        return maxLength == 0 ? 0 : 1.0 - ((double)distance / maxLength);
+    }
+
+    private static int LevenshteinDistance(string left, string right)
+    {
+        if (left.Length == 0) return right.Length;
+        if (right.Length == 0) return left.Length;
+
+        var previous = new int[right.Length + 1];
+        var current = new int[right.Length + 1];
+        for (var j = 0; j <= right.Length; j++)
+            previous[j] = j;
+
+        for (var i = 1; i <= left.Length; i++)
+        {
+            current[0] = i;
+            for (var j = 1; j <= right.Length; j++)
+            {
+                var cost = left[i - 1] == right[j - 1] ? 0 : 1;
+                current[j] = Math.Min(
+                    Math.Min(current[j - 1] + 1, previous[j] + 1),
+                    previous[j - 1] + cost);
+            }
+
+            (previous, current) = (current, previous);
+        }
+
+        return previous[right.Length];
+    }
+
+    private sealed record WikiCandidate(
+        string Kind,
+        string Id,
+        string Name,
+        string SearchText,
+        CardModel? Card,
+        RelicModel? Relic);
+}

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -246,6 +246,13 @@ public static partial class McpMod
                 else
                     SendError(response, 405, "Method not allowed");
             }
+            else if (path == "/api/v1/compendium")
+            {
+                if (request.HttpMethod == "GET")
+                    HandleGetCompendium(response);
+                else
+                    SendError(response, 405, "Method not allowed");
+            }
             else
             {
                 SendError(response, 404, "Not found");

--- a/McpMod.cs
+++ b/McpMod.cs
@@ -253,6 +253,13 @@ public static partial class McpMod
                 else
                     SendError(response, 405, "Method not allowed");
             }
+            else if (path == "/api/v1/wiki")
+            {
+                if (request.HttpMethod == "GET")
+                    HandleGetWiki(request, response);
+                else
+                    SendError(response, 405, "Method not allowed");
+            }
             else
             {
                 SendError(response, 404, "Not found");

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ The MCP server accepts `--host` and `--port` options if you need non-default set
 
 Flag `--no-trust-env` can be used to disable `requests` from picking up proxy settings from the environment, which can cause connection issues if you are running the server in a container.
 
+### Profile and Compendium Data
+
+The HTTP API exposes profile-level progress separately from live run state:
+
+- `GET /api/v1/profile` returns the active profile's persistent progress summary, including discoveries, achievements, epochs, character totals, and global run totals.
+- `GET /api/v1/compendium` groups that progress into the same high-level sections as the in-game Compendium: Card Library, Relic Collection, Potion Lab, Bestiary, Character Stats, and Run History.
+- `GET /api/v1/profiles` lists the three profile slots and the active profile.
+- `POST /api/v1/profiles` switches or deletes profile slots through the game UI.
+
+The MCP server exposes the same profile data through `get_profile()`, `get_compendium()`, `list_profiles()`, `switch_profile(profile_id)`, and `delete_profile(profile_id)`.
+
+`get_compendium()` is intended for agents that need durable context outside the current room or current run. It works from the main menu, includes a `current_run` block while a run is active, and summarizes saved `saves/history/*.run` files for the active profile. Run history is capped to the 20 most recent files in the response so long-lived profiles do not create unbounded tool output.
+
 ## For Developers
 
 ### Build & Install

--- a/README.md
+++ b/README.md
@@ -110,12 +110,15 @@ The HTTP API exposes profile-level progress separately from live run state:
 
 - `GET /api/v1/profile` returns the active profile's persistent progress summary, including discoveries, achievements, epochs, character totals, and global run totals.
 - `GET /api/v1/compendium` groups that progress into the same high-level sections as the in-game Compendium: Card Library, Relic Collection, Potion Lab, Bestiary, Character Stats, and Run History.
+- `GET /api/v1/wiki?query=...` searches discovered card and relic wiki entries for the active profile with fuzzy matching. Results are limited to 10 by default and can be overridden with `limit`; card results include base and upgraded variants when available.
 - `GET /api/v1/profiles` lists the three profile slots and the active profile.
 - `POST /api/v1/profiles` switches or deletes profile slots through the game UI.
 
-The MCP server exposes the same profile data through `get_profile()`, `get_compendium()`, `list_profiles()`, `switch_profile(profile_id)`, and `delete_profile(profile_id)`.
+The MCP server exposes the same profile data through `get_profile()`, `get_compendium()`, `search_wiki(query, item_type, limit)`, `list_profiles()`, `switch_profile(profile_id)`, and `delete_profile(profile_id)`.
 
 `get_compendium()` is intended for agents that need durable context outside the current room or current run. It works from the main menu, includes a `current_run` block while a run is active, and summarizes saved `saves/history/*.run` files for the active profile. Run history is capped to the 20 most recent files in the response so long-lived profiles do not create unbounded tool output.
+
+`search_wiki()` is the selective lookup path for durable card and relic text. It never returns the full game catalog: the mod first filters to the active profile's discovered card and relic IDs, then returns only the best fuzzy matches. Use `item_type="card"` or `item_type="relic"` when the query is known, and raise `limit` only when the default 10 results are not enough.
 
 ## For Developers
 

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -8,6 +8,7 @@ HTTP API served by the STS2_MCP mod on `localhost:15526`. No authentication. Loc
 - `GET  /api/v1/multiplayer` — read multiplayer game state
 - `POST /api/v1/multiplayer` — perform a multiplayer action
 - `GET  /api/v1/profile` — read current profile progress
+- `GET  /api/v1/compendium` — read Compendium-shaped profile progress
 - `GET  /api/v1/profiles` — list profile slots
 - `POST /api/v1/profiles` — switch or delete profile slots
 
@@ -875,6 +876,43 @@ Profile endpoints are independent of the singleplayer and multiplayer run endpoi
 ### `GET /api/v1/profile`
 
 Returns the active profile's persistent progress summary, including character stats, card stats, encounter stats, discovered content, achievements, epochs, and global totals.
+
+### `GET /api/v1/compendium`
+
+Returns the active profile's progress grouped by the in-game Compendium cards:
+
+- `card_library`: discovered card IDs and card pick/skip/win/loss stats. Detailed card metadata lives at `/api/v1/glossary/cards`, which currently requires a run context.
+- `relic_collection`: discovered relic IDs. Detailed relic metadata lives at `/api/v1/glossary/relics`, which currently requires a run context.
+- `potion_lab`: discovered potion IDs. Detailed potion metadata lives at `/api/v1/glossary/potions`, which currently requires a run context.
+- `bestiary`: profile encounter/enemy fight stats plus a pointer to `/api/v1/bestiary` for reflected model metadata. The in-game Bestiary card is currently marked future/locked.
+- `character_stats`: per-character and global profile totals.
+- `run_history`: summaries of the active profile's saved `saves/history/*.run` files. If more than 20 files exist, the response includes the 20 most recent entries and the local `history_path`.
+
+```jsonc
+{
+  "profile_id": 1,
+  "sections": {
+    "card_library": { "status": "exposed", "discovered_ids": ["BASH"], "stats": [] },
+    "relic_collection": { "status": "partially_exposed", "discovered_ids": ["BURNING_BLOOD"] },
+    "potion_lab": { "status": "partially_exposed", "discovered_ids": [] },
+    "bestiary": { "status": "locked_in_ui", "detail_endpoint": "/api/v1/bestiary" },
+    "character_stats": { "status": "exposed", "characters": [], "global": {} },
+    "run_history": {
+      "status": "exposed",
+      "entry_count": 10,
+      "entries": [
+        {
+          "id": "1774869148",
+          "players": [{ "id": 1, "character": "CHARACTER.IRONCLAD" }],
+          "ascension": 0,
+          "win": false,
+          "run_time": 6541
+        }
+      ]
+    }
+  }
+}
+```
 
 ### `GET /api/v1/profiles`
 

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -9,6 +9,7 @@ HTTP API served by the STS2_MCP mod on `localhost:15526`. No authentication. Loc
 - `POST /api/v1/multiplayer` — perform a multiplayer action
 - `GET  /api/v1/profile` — read current profile progress
 - `GET  /api/v1/compendium` — read Compendium-shaped profile progress
+- `GET  /api/v1/wiki` — fuzzy-search discovered card/relic wiki entries
 - `GET  /api/v1/profiles` — list profile slots
 - `POST /api/v1/profiles` — switch or delete profile slots
 
@@ -928,6 +929,75 @@ The response is built from `SaveManager.Progress`, the active profile's `progres
   }
 }
 ```
+
+### `GET /api/v1/wiki`
+
+Searches wiki-style card and relic entries available to the active profile. The endpoint requires a query, filters to the profile's discovered card and relic IDs, fuzzy-ranks the matches, and returns a bounded result set. It does not expose the full game catalog.
+
+Query parameters:
+
+| Parameter | Values | Default | Description |
+|---|---|---|---|
+| `query` or `q` | text | required | Fuzzy search text, such as `ironclad perfect strike` or `silver spoon`. |
+| `item_type` or `type` | `all`, `card`, `relic` | `all` | Restricts the search to one wiki kind. |
+| `limit` | integer | `10` | Maximum returned entries. The mod clamps values below 1 and above its internal maximum. |
+
+Card results include both `base` and `upgraded` variants when the card can be upgraded. The upgraded variant is built from a cloned preview, so the catalog model is not mutated.
+
+```http
+GET /api/v1/wiki?query=ironclad%20perfect%20strike&item_type=card&limit=3
+```
+
+```jsonc
+{
+  "status": "ok",
+  "profile_id": 1,
+  "query": "ironclad perfect strike",
+  "item_type": "card",
+  "limit": 3,
+  "scope": "active_profile_discovered_cards_and_relics",
+  "selection_policy": "Searches only cards and relics discovered by the active profile, then returns the best fuzzy matches instead of exposing the full catalog.",
+  "counts": {
+    "discovered_cards": 42,
+    "discovered_relics": 18,
+    "searched": 42,
+    "returned": 1
+  },
+  "results": [
+    {
+      "item_type": "card",
+      "id": "PERFECTED_STRIKE",
+      "name": "Perfected Strike",
+      "score": 775.123,
+      "rarity": "Common",
+      "type": "Attack",
+      "is_upgradable": true,
+      "base": {
+        "variant": "base",
+        "cost": "2",
+        "description": "Deal ... damage.",
+        "is_upgraded": false,
+        "keywords": []
+      },
+      "upgraded": {
+        "variant": "upgraded",
+        "cost": "2",
+        "description": "Deal ... damage.",
+        "is_upgraded": true,
+        "keywords": []
+      }
+    }
+  ]
+}
+```
+
+Relic searches use the same profile filter and ranking:
+
+```http
+GET /api/v1/wiki?query=silver%20spoon&item_type=relic
+```
+
+Relic results include `id`, `name`, `rarity`, `description`, and `keywords`.
 
 ### `GET /api/v1/profiles`
 

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -881,6 +881,7 @@ Returns the active profile's persistent progress summary, including character st
 
 Returns the active profile's progress grouped by the in-game Compendium cards:
 
+- `current_run`: present while a run is active. Includes a derived `run_id` in `{save_scope}:profile{profile_id}:{start_time}` format, plus `start_time`, `seed`, `save_time`, `run_time`, and run metadata read from `current_run.save`.
 - `card_library`: discovered card IDs and card pick/skip/win/loss stats. Detailed card metadata lives at `/api/v1/glossary/cards`, which currently requires a run context.
 - `relic_collection`: discovered relic IDs. Detailed relic metadata lives at `/api/v1/glossary/relics`, which currently requires a run context.
 - `potion_lab`: discovered potion IDs. Detailed potion metadata lives at `/api/v1/glossary/potions`, which currently requires a run context.
@@ -891,6 +892,15 @@ Returns the active profile's progress grouped by the in-game Compendium cards:
 ```jsonc
 {
   "profile_id": 1,
+  "current_run": {
+    "is_in_progress": true,
+    "profile_id": 1,
+    "save_scope": "modded",
+    "run_id": "modded:profile1:1778295706",
+    "start_time": 1778295706,
+    "seed": "2450ZAR9EF",
+    "run_time": 137
+  },
   "sections": {
     "card_library": { "status": "exposed", "discovered_ids": ["BASH"], "stats": [] },
     "relic_collection": { "status": "partially_exposed", "discovered_ids": ["BURNING_BLOOD"] },
@@ -903,6 +913,7 @@ Returns the active profile's progress grouped by the in-game Compendium cards:
       "entries": [
         {
           "id": "1774869148",
+          "run_id": "modded:profile1:1774869148",
           "players": [{ "id": 1, "character": "CHARACTER.IRONCLAD" }],
           "ascension": 0,
           "win": false,

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -882,12 +882,16 @@ Returns the active profile's persistent progress summary, including character st
 Returns the active profile's progress grouped by the in-game Compendium cards:
 
 - `current_run`: present while a run is active. Includes a derived `run_id` in `{save_scope}:profile{profile_id}:{start_time}` format, plus `start_time`, `seed`, `save_time`, `run_time`, and run metadata read from `current_run.save`.
-- `card_library`: discovered card IDs and card pick/skip/win/loss stats. Detailed card metadata lives at `/api/v1/glossary/cards`, which currently requires a run context.
-- `relic_collection`: discovered relic IDs. Detailed relic metadata lives at `/api/v1/glossary/relics`, which currently requires a run context.
-- `potion_lab`: discovered potion IDs. Detailed potion metadata lives at `/api/v1/glossary/potions`, which currently requires a run context.
-- `bestiary`: profile encounter/enemy fight stats plus a pointer to `/api/v1/bestiary` for reflected model metadata. The in-game Bestiary card is currently marked future/locked.
+- `card_library`: discovered card IDs and card pick/skip/win/loss stats. This endpoint intentionally reports profile-level progress; card rules text remains available through game state when cards are visible in a run.
+- `relic_collection`: discovered relic IDs. The profile save exposes discovery, but not a typed per-relic description or obtained-count catalog.
+- `potion_lab`: discovered potion IDs. The profile save exposes discovery, but not a typed per-potion rules text or lab metadata catalog.
+- `bestiary`: profile encounter/enemy fight stats. The in-game Bestiary card is currently marked future/locked, so this section is stats-only and does not expose a full enemy metadata catalog.
 - `character_stats`: per-character and global profile totals.
 - `run_history`: summaries of the active profile's saved `saves/history/*.run` files. If more than 20 files exist, the response includes the 20 most recent entries and the local `history_path`.
+
+The response is built from `SaveManager.Progress`, the active profile's `progress.save` path, and local run-history files under the same active Steam account. It does not scan every Steam account under the save root. Run-history parsing is bounded to the 20 most recent `.run` files in the response so profile pages with many saved runs do not return unbounded payloads.
+
+`current_run.run_id` is derived from save scope, profile id, and run `start_time`. Use it to identify one concrete run attempt. Use `seed` separately when grouping runs by generated content, because multiple attempts can share the same seed.
 
 ```jsonc
 {
@@ -905,7 +909,7 @@ Returns the active profile's progress grouped by the in-game Compendium cards:
     "card_library": { "status": "exposed", "discovered_ids": ["BASH"], "stats": [] },
     "relic_collection": { "status": "partially_exposed", "discovered_ids": ["BURNING_BLOOD"] },
     "potion_lab": { "status": "partially_exposed", "discovered_ids": [] },
-    "bestiary": { "status": "locked_in_ui", "detail_endpoint": "/api/v1/bestiary" },
+    "bestiary": { "status": "locked_in_ui", "encounter_stats": [], "enemy_stats": [] },
     "character_stats": { "status": "exposed", "characters": [], "global": {} },
     "run_history": {
       "status": "exposed",

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -65,6 +65,8 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 `GET /api/v1/compendium` returns the active profile grouped like the in-game Compendium:
 
+When a run is active, the response includes `current_run.run_id` in `{save_scope}:profile{profile_id}:{start_time}` format. This identifies the specific run attempt, while `seed` identifies the generated run content.
+
 | Section | Status |
 |---|---|
 | `card_library` | Discovered cards and card stats; `/api/v1/glossary/cards` adds metadata when a run context exists. |

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -8,6 +8,7 @@ HTTP API on `localhost:15526`. No authentication.
 - `POST /api/v1/multiplayer` — perform multiplayer action
 - `GET /api/v1/profile` — read current profile progress
 - `GET /api/v1/compendium` — read Compendium-shaped profile progress
+- `GET /api/v1/wiki` — fuzzy-search discovered card/relic wiki entries
 - `GET /api/v1/profiles` — list profile slots
 - `POST /api/v1/profiles` — switch or delete profile slots
 
@@ -77,6 +78,13 @@ When a run is active, the response includes `current_run.run_id` in `{save_scope
 | `run_history` | Summaries of the active profile's saved `saves/history/*.run` files, capped to the 20 most recent entries. |
 
 Run history is resolved from the active Steam account's profile save root. `current_run.run_id` identifies one concrete attempt; `seed` identifies generated run content and can repeat across attempts.
+
+`GET /api/v1/wiki?query=<text>&item_type=<all|card|relic>&limit=<n>` returns a bounded fuzzy-search result over the active profile's discovered cards and relics. `query` is required because this endpoint is intentionally selective and does not dump the full catalog. `item_type` defaults to `all`, and `limit` defaults to 10 with an internal maximum. Card results include both `base` and `upgraded` objects when the card can be upgraded.
+
+Example searches:
+
+- `/api/v1/wiki?query=ironclad%20perfect%20strike&item_type=card`
+- `/api/v1/wiki?query=silver%20spoon&item_type=relic&limit=5`
 
 `GET /api/v1/profiles` returns the three profile slots:
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -7,6 +7,7 @@ HTTP API on `localhost:15526`. No authentication.
 - `GET /api/v1/multiplayer` — read multiplayer state
 - `POST /api/v1/multiplayer` — perform multiplayer action
 - `GET /api/v1/profile` — read current profile progress
+- `GET /api/v1/compendium` — read Compendium-shaped profile progress
 - `GET /api/v1/profiles` — list profile slots
 - `POST /api/v1/profiles` — switch or delete profile slots
 
@@ -61,6 +62,17 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 ### Profiles
 
 `GET /api/v1/profile` returns persistent progress for the active profile, including character stats, discoveries, achievements, epochs, and global run totals.
+
+`GET /api/v1/compendium` returns the active profile grouped like the in-game Compendium:
+
+| Section | Status |
+|---|---|
+| `card_library` | Discovered cards and card stats; `/api/v1/glossary/cards` adds metadata when a run context exists. |
+| `relic_collection` | Discovered relic IDs; `/api/v1/glossary/relics` adds metadata when a run context exists. |
+| `potion_lab` | Discovered potion IDs; `/api/v1/glossary/potions` adds metadata when a run context exists. |
+| `bestiary` | Encounter/enemy profile stats plus `/api/v1/bestiary` model metadata. The game UI marks Bestiary as future/locked. |
+| `character_stats` | Per-character and global totals. |
+| `run_history` | Summaries of the active profile's saved `saves/history/*.run` files, capped to the 20 most recent entries. |
 
 `GET /api/v1/profiles` returns the three profile slots:
 

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -69,12 +69,14 @@ When a run is active, the response includes `current_run.run_id` in `{save_scope
 
 | Section | Status |
 |---|---|
-| `card_library` | Discovered cards and card stats; `/api/v1/glossary/cards` adds metadata when a run context exists. |
-| `relic_collection` | Discovered relic IDs; `/api/v1/glossary/relics` adds metadata when a run context exists. |
-| `potion_lab` | Discovered potion IDs; `/api/v1/glossary/potions` adds metadata when a run context exists. |
-| `bestiary` | Encounter/enemy profile stats plus `/api/v1/bestiary` model metadata. The game UI marks Bestiary as future/locked. |
+| `card_library` | Discovered cards plus pick/skip/win/loss stats. Card rules text is supplied by game state when cards are visible in a run. |
+| `relic_collection` | Discovered relic IDs. Profile data does not expose a typed per-relic description or obtained-count catalog. |
+| `potion_lab` | Discovered potion IDs. Profile data does not expose a typed per-potion rules text or lab metadata catalog. |
+| `bestiary` | Encounter/enemy profile fight stats. The game UI marks Bestiary as future/locked, so this is stats-only rather than a full enemy catalog. |
 | `character_stats` | Per-character and global totals. |
 | `run_history` | Summaries of the active profile's saved `saves/history/*.run` files, capped to the 20 most recent entries. |
+
+Run history is resolved from the active Steam account's profile save root. `current_run.run_id` identifies one concrete attempt; `seed` identifies generated run content and can repeat across attempts.
 
 `GET /api/v1/profiles` returns the three profile slots:
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -7,6 +7,7 @@
 | `get_game_state(format?)` | General | Get current game state (`markdown` or `json`) |
 | `menu_select(option, seed?)` | General | Select a visible menu/game-over option |
 | `get_profile()` | Profiles | Get active profile progress |
+| `get_compendium()` | Profiles | Get active profile progress grouped like the in-game Compendium |
 | `list_profiles()` | Profiles | List profile slots and active slot |
 | `switch_profile(profile_id)` | Profiles | Switch to a profile slot through the game UI |
 | `delete_profile(profile_id)` | Profiles | Delete an inactive profile slot |
@@ -37,6 +38,14 @@
 | `crystal_sphere_set_tool(tool)` | Crystal Sphere | Switch the active divination tool |
 | `crystal_sphere_click_cell(x, y)` | Crystal Sphere | Click a hidden cell in the grid |
 | `crystal_sphere_proceed()` | Crystal Sphere | Continue after the minigame finishes |
+
+### Profile Tools
+
+`get_profile()` returns the raw active-profile progress summary: character totals, global totals, discoveries, achievements, epochs, and aggregate stats.
+
+`get_compendium()` presents the same profile data in the shape agents usually need when reasoning about long-term progress. It groups the response into `card_library`, `relic_collection`, `potion_lab`, `bestiary`, `character_stats`, and `run_history`, matching the high-level Compendium cards in the game UI. It also includes `current_run` while a run is active, with a derived `run_id` in `{save_scope}:profile{profile_id}:{start_time}` format.
+
+The Compendium response is profile-scoped, not run-state-scoped. It works from the main menu, does not require navigating the in-game Compendium UI, and summarizes only the 20 most recent saved run-history files to keep the MCP response bounded.
 
 ## Multiplayer
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,6 +8,7 @@
 | `menu_select(option, seed?)` | General | Select a visible menu/game-over option |
 | `get_profile()` | Profiles | Get active profile progress |
 | `get_compendium()` | Profiles | Get active profile progress grouped like the in-game Compendium |
+| `search_wiki(query, item_type?, limit?)` | Profiles | Fuzzy-search discovered card and relic wiki entries |
 | `list_profiles()` | Profiles | List profile slots and active slot |
 | `switch_profile(profile_id)` | Profiles | Switch to a profile slot through the game UI |
 | `delete_profile(profile_id)` | Profiles | Delete an inactive profile slot |
@@ -46,6 +47,8 @@
 `get_compendium()` presents the same profile data in the shape agents usually need when reasoning about long-term progress. It groups the response into `card_library`, `relic_collection`, `potion_lab`, `bestiary`, `character_stats`, and `run_history`, matching the high-level Compendium cards in the game UI. It also includes `current_run` while a run is active, with a derived `run_id` in `{save_scope}:profile{profile_id}:{start_time}` format.
 
 The Compendium response is profile-scoped, not run-state-scoped. It works from the main menu, does not require navigating the in-game Compendium UI, and summarizes only the 20 most recent saved run-history files to keep the MCP response bounded.
+
+`search_wiki(query, item_type="all", limit=10)` is the selective wiki lookup. It fuzzy-matches names and IDs such as `ironclad perfect strike` or `silver spoon`, but it searches only cards and relics discovered by the active profile. The default response is capped at 10 entries; callers may pass a higher or lower `limit`, and the mod clamps oversized requests. Card matches include `base` and `upgraded` blocks so agents can compare pre-upgrade and post-upgrade text without asking for the full card library.
 
 ## Multiplayer
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -214,9 +214,10 @@ async def get_compendium() -> str:
     """Get the active profile's Compendium-shaped progress summary.
 
     Mirrors the visible Compendium cards: Card Library, Relic Collection,
-    Potion Lab, Bestiary, Character Stats, and Run History. Some sections point
-    to detail endpoints such as glossary or bestiary when model-level metadata is
-    separate from profile discovery/progress data.
+    Potion Lab, Bestiary, Character Stats, and Run History. This is a
+    profile-level view, so it is useful at the main menu as well as during a run.
+    Card/relic/potion rules text is still supplied by game state when those
+    objects are visible in run-specific contexts.
     """
     try:
         return await _compendium_get()

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -31,6 +31,10 @@ def _profile_url() -> str:
     return f"{_base_url}/api/v1/profile"
 
 
+def _compendium_url() -> str:
+    return f"{_base_url}/api/v1/compendium"
+
+
 def _profiles_url() -> str:
     return f"{_base_url}/api/v1/profiles"
 
@@ -68,6 +72,12 @@ async def _mp_post(body: dict) -> str:
 
 async def _profile_get() -> str:
     r = await _get_client().get(_profile_url())
+    r.raise_for_status()
+    return r.text
+
+
+async def _compendium_get() -> str:
+    r = await _get_client().get(_compendium_url())
     r.raise_for_status()
     return r.text
 
@@ -195,6 +205,21 @@ async def get_profile() -> str:
     """
     try:
         return await _profile_get()
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def get_compendium() -> str:
+    """Get the active profile's Compendium-shaped progress summary.
+
+    Mirrors the visible Compendium cards: Card Library, Relic Collection,
+    Potion Lab, Bestiary, Character Stats, and Run History. Some sections point
+    to detail endpoints such as glossary or bestiary when model-level metadata is
+    separate from profile discovery/progress data.
+    """
+    try:
+        return await _compendium_get()
     except Exception as e:
         return _handle_error(e)
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -35,6 +35,10 @@ def _compendium_url() -> str:
     return f"{_base_url}/api/v1/compendium"
 
 
+def _wiki_url() -> str:
+    return f"{_base_url}/api/v1/wiki"
+
+
 def _profiles_url() -> str:
     return f"{_base_url}/api/v1/profiles"
 
@@ -78,6 +82,15 @@ async def _profile_get() -> str:
 
 async def _compendium_get() -> str:
     r = await _get_client().get(_compendium_url())
+    r.raise_for_status()
+    return r.text
+
+
+async def _wiki_get(query: str, item_type: str = "all", limit: int = 10) -> str:
+    r = await _get_client().get(
+        _wiki_url(),
+        params={"query": query, "item_type": item_type, "limit": limit},
+    )
     r.raise_for_status()
     return r.text
 
@@ -221,6 +234,27 @@ async def get_compendium() -> str:
     """
     try:
         return await _compendium_get()
+    except Exception as e:
+        return _handle_error(e)
+
+
+@mcp.tool()
+async def search_wiki(query: str, item_type: str = "all", limit: int = 10) -> str:
+    """Search discovered card and relic wiki entries for the active profile.
+
+    Uses fuzzy matching over profile-unlocked content only, so agents can ask
+    for a card or relic by approximate name without receiving the entire game
+    catalog. Card results include both base and upgraded variants when the card
+    can be upgraded.
+
+    Args:
+        query: Search text such as "ironclad perfect strike" or "silver spoon".
+        item_type: "all", "card", or "relic".
+        limit: Maximum results to return. Defaults to 10; the mod clamps it to
+            a bounded maximum.
+    """
+    try:
+        return await _wiki_get(query, item_type, limit)
     except Exception as e:
         return _handle_error(e)
 


### PR DESCRIPTION
## Summary

Ports the Compendium implementation from https://github.com/romgenie/STS2MCP/pull/1 onto `Gennadiyev/STS2MCP`, then extends the PR with a selective profile-scoped wiki search requested in review.

This adds profile-level Compendium and Wiki lookup paths so agents can inspect durable progress and retrieve specific card/relic rules text without navigating the in-game Compendium UI or dumping the full game catalog.

## What Changed

- Adds `GET /api/v1/compendium`.
- Adds `GET /api/v1/wiki` for bounded fuzzy search over active-profile discovered cards and relics.
- Adds MCP tools `get_compendium()` and `search_wiki(query, item_type="all", limit=10)`.
- Adds `McpMod.Compendium.cs` to build a Compendium-shaped response from active profile data.
- Adds `McpMod.Wiki.cs` to resolve discovered card/relic models, fuzzy-rank matches, and serialize card/relic wiki entries.
- Extends profile save path resolution so profile slot `has_data` and Compendium run-history lookup resolve STS2-relative profile paths against the actual local save roots.
- Replaces a removed `LoadRunLobby.IsAboutToBeginGame()` call with readiness derivation from connected player IDs and ready flags so the branch builds against the current game DLL.
- Documents the endpoints in:
  - `README.md`
  - `mcp/README.md`
  - `docs/raw-full.md`
  - `docs/raw-simplified.md`

## Compendium Endpoint Shape

`GET /api/v1/compendium` returns:

- `profile_id`
- `current_run`, when a run is active
- `sections.card_library`
- `sections.relic_collection`
- `sections.potion_lab`
- `sections.bestiary`
- `sections.character_stats`
- `sections.run_history`

The shape intentionally mirrors the high-level cards in the in-game Compendium. It is meant to help agents reason about long-term profile context, unlocked/discovered content, character totals, and previous run history without manually driving menu UI.

## Wiki Search

`GET /api/v1/wiki` is the selective lookup route for card and relic rules text.

Query parameters:

- `query` or `q`: required fuzzy search text, such as `ironclad perfect strike` or `silver spoon`.
- `item_type` or `type`: `all`, `card`, or `relic`; defaults to `all`.
- `limit`: maximum returned entries; defaults to 10 and is clamped by the mod.

The endpoint first filters to the active profile's discovered card and relic IDs, then fuzzy-ranks only that filtered set. It intentionally refuses empty queries so agents cannot receive the full catalog by accident.

Card results include both `base` and `upgraded` blocks when a card can be upgraded. The upgraded block is built from a cloned preview so the source model is not mutated. Relic results include name, rarity, description, and keywords.

The MCP `search_wiki()` tool exposes the same behavior to agents with the same default limit and item-type override.

## Run Identity

When a current run is available, the endpoint derives:

```text
{save_scope}:profile{profile_id}:{start_time}
```

as `current_run.run_id`.

That value identifies one concrete attempt. `seed` remains separate because multiple run attempts can share generated content while still being distinct attempts.

## Run History

The endpoint summarizes saved `.run` files from the active profile's `saves/history` directory.

The response is bounded to the 20 most recent files so long-lived profiles do not produce unbounded API or MCP output. The response includes `history_path` and `entry_count` so consumers can tell when more local history exists than was returned.

## Save Root Resolution

STS2 APIs may return profile-relative paths such as `profile1/...` or `modded/profile1/...`. This implementation resolves those relative paths under the active Steam account save root before reading profile progress and run history.

The implementation also probes common XDG-style save roots for Linux/Steam environments and restricts run-history resolution to the active account path when it can be inferred.

## Upstream Adjustment From Source PR

The source PR was developed in `romgenie/STS2MCP`, which also had fork-local glossary and bestiary endpoints. `Gennadiyev/main` does not currently expose those endpoints, so this PR removes those references from the imported response/docs rather than advertising routes that would return 404.

The Compendium endpoint still exposes:

- profile-level card discovery and aggregate card stats
- relic and potion discovery IDs
- encounter and enemy fight stats available from profile progress
- character and global profile totals
- current-run identity
- saved run-history summaries

## Validation

- `python3 -m py_compile mcp/server.py`
- `"/mnt/c/Program Files/dotnet/dotnet.exe" build`

The .NET build completed successfully with 0 warnings and 0 errors.