### PR TITLE
[codex] Expose map boss identity

### DIFF
--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -1701,18 +1701,120 @@ public static partial class McpMod
             nodes.Add(BuildMapNode(pt));
 
         // Boss
-        nodes.Add(BuildMapNode(map.BossMapPoint));
+        var primaryBossId = ReadModelIdEntry(runState, "BossId")
+            ?? ReadModelIdEntry(map, "BossId")
+            ?? ReadModelIdEntry(map.BossMapPoint, "BossId", "EncounterId");
+        var bossNode = BuildMapNode(map.BossMapPoint);
+        AddBossIdentity(bossNode, primaryBossId);
+        nodes.Add(bossNode);
+
+        Dictionary<string, object?>? secondBoss = null;
         if (map.SecondBossMapPoint != null)
-            nodes.Add(BuildMapNode(map.SecondBossMapPoint));
+        {
+            var secondBossId = ReadModelIdEntry(runState, "SecondBossId")
+                ?? ReadModelIdEntry(map, "SecondBossId")
+                ?? ReadModelIdEntry(map.SecondBossMapPoint, "SecondBossId", "BossId", "EncounterId");
+            var secondBossNode = BuildMapNode(map.SecondBossMapPoint);
+            AddBossIdentity(secondBossNode, secondBossId);
+            nodes.Add(secondBossNode);
+            secondBoss = BuildBossInfo(map.SecondBossMapPoint, secondBossId);
+        }
 
         state["nodes"] = nodes;
-        state["boss"] = new Dictionary<string, object?>
-        {
-            ["col"] = map.BossMapPoint.coord.col,
-            ["row"] = map.BossMapPoint.coord.row
-        };
+        var primaryBoss = BuildBossInfo(map.BossMapPoint, primaryBossId);
+        state["boss"] = primaryBoss;
+        state["bosses"] = secondBoss != null
+            ? new List<Dictionary<string, object?>> { primaryBoss, secondBoss }
+            : new List<Dictionary<string, object?>> { primaryBoss };
 
         return state;
+    }
+
+    private static Dictionary<string, object?> BuildBossInfo(MapPoint pt, string? bossId)
+    {
+        var boss = new Dictionary<string, object?>
+        {
+            ["col"] = pt.coord.col,
+            ["row"] = pt.coord.row
+        };
+        AddBossIdentity(boss, bossId);
+        return boss;
+    }
+
+    private static void AddBossIdentity(Dictionary<string, object?> target, string? bossId)
+    {
+        if (string.IsNullOrWhiteSpace(bossId))
+            return;
+
+        target["id"] = bossId;
+        target["name"] = BuildDisplayNameFromId(bossId);
+    }
+
+    private static string? ReadModelIdEntry(object? source, params string[] memberNames)
+    {
+        foreach (var memberName in memberNames)
+        {
+            var value = GetMemberValue(source, memberName);
+            if (value == null)
+                continue;
+
+            var entry = GetMemberValue(value, "Entry")?.ToString();
+            if (!string.IsNullOrWhiteSpace(entry))
+                return entry;
+
+            var text = value.ToString();
+            if (!string.IsNullOrWhiteSpace(text))
+                return text;
+        }
+
+        return null;
+    }
+
+    private static object? GetMemberValue(object? source, string memberName)
+    {
+        if (source == null)
+            return null;
+
+        const System.Reflection.BindingFlags Flags =
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.NonPublic;
+
+        for (var type = source.GetType(); type != null; type = type.BaseType)
+        {
+            var property = type.GetProperty(memberName, Flags);
+            if (property != null && property.GetIndexParameters().Length == 0)
+            {
+                try { return property.GetValue(source); }
+                catch { return null; }
+            }
+
+            var field = type.GetField(memberName, Flags);
+            if (field != null)
+            {
+                try { return field.GetValue(source); }
+                catch { return null; }
+            }
+        }
+
+        return null;
+    }
+
+    private static string BuildDisplayNameFromId(string id)
+    {
+        var lastSegment = id
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault() ?? id;
+        if (lastSegment.EndsWith("_BOSS", StringComparison.OrdinalIgnoreCase))
+            lastSegment = lastSegment[..^5];
+
+        var words = lastSegment
+            .Replace('-', '_')
+            .Split('_', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return words.Length == 0
+            ? id
+            : string.Join(" ", words.Select(word => char.ToUpperInvariant(word[0]) + word[1..].ToLowerInvariant()));
     }
 
     private static Dictionary<string, object?> BuildMapNode(MapPoint pt)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -1754,11 +1754,11 @@ public static partial class McpMod
     {
         foreach (var memberName in memberNames)
         {
-            var value = GetMemberValue(source, memberName);
+            var value = GetBossMemberValue(source, memberName);
             if (value == null)
                 continue;
 
-            var entry = GetMemberValue(value, "Entry")?.ToString();
+            var entry = GetBossMemberValue(value, "Entry")?.ToString();
             if (!string.IsNullOrWhiteSpace(entry))
                 return entry;
 
@@ -1770,7 +1770,7 @@ public static partial class McpMod
         return null;
     }
 
-    private static object? GetMemberValue(object? source, string memberName)
+    private static object? GetBossMemberValue(object? source, string memberName)
     {
         if (source == null)
             return null;

--- a/docs/raw-full.md
+++ b/docs/raw-full.md
@@ -495,7 +495,15 @@ Pick one card to add to your deck. Appears after claiming a card reward, or dire
         "children": [ [2, 1], [3, 1], [4, 1] ]  // [col, row] pairs
       }
     ],
-    "boss": { "col": 3, "row": 15 }
+    "boss": {
+      "col": 3,
+      "row": 15,
+      "id": "ENCOUNTER.VANTOM_BOSS",
+      "name": "Vantom"
+    },
+    "bosses": [
+      { "col": 3, "row": 15, "id": "ENCOUNTER.VANTOM_BOSS", "name": "Vantom" }
+    ]
   },
   "run": { ... },
   "player": { ... }

--- a/docs/raw-simplified.md
+++ b/docs/raw-simplified.md
@@ -114,6 +114,8 @@ All POST requests use JSON body with `"action"` field. All responses include `{ 
 
 ### Map (`map`)
 
+`map.boss` includes the upcoming boss coordinate plus stable `id` and readable `name` fields when the run map exposes boss identity. `map.bosses` contains all boss entries for maps with more than one boss.
+
 | Action | Parameters | When to Use |
 |---|---|---|
 | `choose_map_node` | `index`: int | Travel to a node from `next_options`. |


### PR DESCRIPTION
## Summary

Fixes #74 by adding boss identity metadata to map state.

`map.boss` now keeps the existing `col` / `row` fields and adds:

- `id`: stable encounter/model id when available, for example `ENCOUNTER.VANTOM_BOSS`
- `name`: readable name derived from the id, for example `Vantom`

The map response also includes `map.bosses`, which contains the primary boss and the optional second boss for maps that expose one. Boss nodes in `map.nodes` receive the same `id` / `name` fields, so path planners can see identity both from the shortcut field and the full map DAG.

## Implementation Notes

`ActMap` does not expose `BossId` as a public compile-time member in the current game DLL, so this uses a defensive reflected lookup across `RunState`, `ActMap`, and the boss `MapPoint`. If the game cannot expose the id, the response preserves the old coordinate-only shape instead of failing map serialization.

## Docs

Updated:

- `docs/raw-full.md`
- `docs/raw-simplified.md`

## Validation

- `"/mnt/c/Program Files/dotnet/dotnet.exe" build STS2_MCP.csproj -c Release -o out/STS2_MCP -p:STS2GameDir="C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2"`

Build completed with 0 warnings and 0 errors.
