### PR TITLE
Fix Crystal Sphere proceed button detection

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -1028,8 +1028,8 @@ public static partial class McpMod
         if (overlay is not NCrystalSphereScreen screen)
             return Error("Crystal Sphere screen is not open");
 
-        var proceedButton = screen.GetNodeOrNull<NProceedButton>("%ProceedButton");
-        if (proceedButton is not { IsEnabled: true })
+        var proceedButton = FindCrystalSphereProceedButton(screen);
+        if (proceedButton == null)
             return Error("Crystal Sphere proceed button is not enabled");
 
         proceedButton.ForceClick();
@@ -1038,6 +1038,16 @@ public static partial class McpMod
             ["status"] = "ok",
             ["message"] = "Proceeding from Crystal Sphere"
         };
+    }
+
+    private static NProceedButton? FindCrystalSphereProceedButton(NCrystalSphereScreen screen)
+    {
+        var namedButton = screen.GetNodeOrNull<NProceedButton>("%ProceedButton");
+        if (IsControlVisibleOrActionable(namedButton))
+            return namedButton;
+
+        return FindAll<NProceedButton>(screen)
+            .FirstOrDefault(IsControlVisibleOrActionable);
     }
 
     private static Creature? ResolveTarget(CombatState combatState, string entityId)

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -2184,8 +2184,7 @@ public static partial class McpMod
                 state["divinations_left_text"] = StripRichTextTags(textVariant.AsString());
         }
 
-        var proceedButton = screen.GetNodeOrNull<NProceedButton>("%ProceedButton");
-        state["can_proceed"] = proceedButton?.IsEnabled == true;
+        state["can_proceed"] = FindCrystalSphereProceedButton(screen) != null;
 
         return state;
     }


### PR DESCRIPTION
## Summary

Fixes #73 by making Crystal Sphere proceed detection use the same visible/actionable control checks used elsewhere in the mod.

- Finds the named `%ProceedButton` only when it is visible, in-tree, and enabled
- Falls back to any visible/actionable `NProceedButton` under the Crystal Sphere screen
- Uses the same helper for `crystal_sphere.can_proceed` and `crystal_sphere_proceed()` so state and action behavior stay aligned

## Validation

- `git diff --check`
- `dotnet build -p:STS2GameDir="/Users/zhengweisun/Library/Application Support/Steam/steamapps/common/Slay the Spire 2"`

Build completed with 0 warnings and 0 errors.
