### PR TITLE
Fix compatibility with current STS2 combat API

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -95,7 +95,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsPlayPhase())
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -150,7 +150,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsPlayPhase())
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled (turn may already be ending)");
@@ -193,7 +193,7 @@ public static partial class McpMod
         {
             if (!inCombat)
                 return Error($"Potion '{SafeGetText(() => potion.Title)}' can only be used in combat");
-            if (!CombatManager.Instance.IsPlayPhase)
+            if (!IsPlayPhase())
                 return Error("Cannot use potions outside of play phase");
         }
         else if (potion.Usage == PotionUsage.Automatic)
@@ -362,7 +362,7 @@ public static partial class McpMod
             var merchUI = NMerchantRoom.Instance;
             if (merchUI?.Inventory != null && !merchUI.Inventory.IsOpen)
                 merchUI.OpenInventory();
-            inventory = merchantRoom.Inventory;
+            inventory = merchantRoom.GetLocalInventory();
         }
         else if (player.RunState.CurrentRoom is EventRoom eventRoom
                  && eventRoom.CanonicalEvent is FakeMerchant
@@ -1050,7 +1050,7 @@ public static partial class McpMod
             .FirstOrDefault(IsControlVisibleOrActionable);
     }
 
-    private static Creature? ResolveTarget(CombatState combatState, string entityId)
+    private static Creature? ResolveTarget(ICombatState combatState, string entityId)
     {
         // Try to match by entity_id pattern: "model_entry_N"
         // First try matching by combat_id if it's a pure number

--- a/McpMod.CombatCompat.cs
+++ b/McpMod.CombatCompat.cs
@@ -1,0 +1,22 @@
+using MegaCrit.Sts2.Core.Combat;
+
+namespace STS2_MCP;
+
+public static partial class McpMod
+{
+    private static bool IsPlayPhase()
+    {
+        return IsPlayPhase(CombatManager.Instance.DebugOnlyGetState());
+    }
+
+    private static bool IsPlayPhase(CombatState? combatState)
+    {
+        var manager = CombatManager.Instance;
+        return manager.IsInProgress
+            && combatState?.CurrentSide == CombatSide.Player
+            && !manager.PlayerActionsDisabled
+            && !manager.IsEnemyTurnStarted
+            && !manager.EndingPlayerTurnPhaseOne
+            && !manager.EndingPlayerTurnPhaseTwo;
+    }
+}

--- a/McpMod.MultiplayerActions.cs
+++ b/McpMod.MultiplayerActions.cs
@@ -73,7 +73,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsPlayPhase())
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -106,7 +106,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!IsPlayPhase())
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");

--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -269,7 +269,7 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        battle["is_play_phase"] = IsPlayPhase(combatState);
         battle["all_players_ready"] = CombatManager.Instance.AllPlayersReadyToEndTurn();
 
         // Enemies

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -1072,7 +1072,7 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        battle["is_play_phase"] = IsPlayPhase(combatState);
 
         // Enemies
         var enemies = new List<Dictionary<string, object?>>();
@@ -1531,7 +1531,7 @@ public static partial class McpMod
     {
         var state = new Dictionary<string, object?>();
 
-        var inventory = merchantRoom.Inventory;
+        var inventory = merchantRoom.GetLocalInventory();
         if (inventory == null)
         {
             state["items"] = new List<Dictionary<string, object?>>();


### PR DESCRIPTION
Hello and thanks for the amazing API! I'm attempting to write a machine learning bot to get good at playing STS2, so I am building on top of your work. However, I found this bug. The below description is from a LLM:

## Summary
- replace `CombatManager.Instance.IsPlayPhase` calls with a helper based on current combat state/manager properties
- update `MerchantRoom.Inventory` usages to `GetLocalInventory()`
- allow target resolution against `ICombatState`

## Validation
- `dotnet build "STS2_MCP.csproj" -c Release -o "out\STS2_MCP" -p:STS2GameDir="C:\Program Files (x86)\Steam\steamapps\common\Slay the Spire 2" --no-restore`
- installed the rebuilt mod locally and verified `GET /api/v1/singleplayer` works during combat, returning `state_type: "monster"` and `battle.is_play_phase: true`

## Context
With the current STS2 build, combat state reads fail with:

```text
MissingMethodException: CombatManager.get_IsPlayPhase()
```

The current game API exposes related state through `CombatState.CurrentSide` plus `CombatManager` phase flags instead of `IsPlayPhase`.