### PR TITLE
fix: restore compatibility with STS2 v0.107.1

### DIFF
--- a/McpMod.Actions.cs
+++ b/McpMod.Actions.cs
@@ -95,7 +95,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!CombatManager.Instance.IsPartOfPlayerTurn(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -150,7 +150,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!CombatManager.Instance.IsPartOfPlayerTurn(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled (turn may already be ending)");
@@ -193,7 +193,7 @@ public static partial class McpMod
         {
             if (!inCombat)
                 return Error($"Potion '{SafeGetText(() => potion.Title)}' can only be used in combat");
-            if (!CombatManager.Instance.IsPlayPhase)
+            if (!CombatManager.Instance.IsPartOfPlayerTurn(player))
                 return Error("Cannot use potions outside of play phase");
         }
         else if (potion.Usage == PotionUsage.Automatic)
@@ -362,7 +362,7 @@ public static partial class McpMod
             var merchUI = NMerchantRoom.Instance;
             if (merchUI?.Inventory != null && !merchUI.Inventory.IsOpen)
                 merchUI.OpenInventory();
-            inventory = merchantRoom.Inventory;
+            inventory = merchantRoom.GetLocalInventory();
         }
         else if (player.RunState.CurrentRoom is EventRoom eventRoom
                  && eventRoom.CanonicalEvent is FakeMerchant
@@ -1050,7 +1050,7 @@ public static partial class McpMod
             .FirstOrDefault(IsControlVisibleOrActionable);
     }
 
-    private static Creature? ResolveTarget(CombatState combatState, string entityId)
+    private static Creature? ResolveTarget(ICombatState combatState, string entityId)
     {
         // Try to match by entity_id pattern: "model_entry_N"
         // First try matching by combat_id if it's a pure number

--- a/McpMod.MultiplayerActions.cs
+++ b/McpMod.MultiplayerActions.cs
@@ -73,7 +73,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!CombatManager.Instance.IsPartOfPlayerTurn(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");
@@ -106,7 +106,7 @@ public static partial class McpMod
     {
         if (!CombatManager.Instance.IsInProgress)
             return Error("Not in combat");
-        if (!CombatManager.Instance.IsPlayPhase)
+        if (!CombatManager.Instance.IsPartOfPlayerTurn(player))
             return Error("Not in play phase - cannot act during enemy turn");
         if (CombatManager.Instance.PlayerActionsDisabled)
             return Error("Player actions are currently disabled");

--- a/McpMod.MultiplayerState.cs
+++ b/McpMod.MultiplayerState.cs
@@ -269,7 +269,8 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        var player = LocalContext.GetMe(runState);
+        battle["is_play_phase"] = player != null && CombatManager.Instance.IsPartOfPlayerTurn(player);
         battle["all_players_ready"] = CombatManager.Instance.AllPlayersReadyToEndTurn();
 
         // Enemies

--- a/McpMod.StateBuilder.cs
+++ b/McpMod.StateBuilder.cs
@@ -1072,7 +1072,8 @@ public static partial class McpMod
 
         battle["round"] = combatState.RoundNumber;
         battle["turn"] = combatState.CurrentSide.ToString().ToLower();
-        battle["is_play_phase"] = CombatManager.Instance.IsPlayPhase;
+        var player = LocalContext.GetMe(runState);
+        battle["is_play_phase"] = player != null && CombatManager.Instance.IsPartOfPlayerTurn(player);
 
         // Enemies
         var enemies = new List<Dictionary<string, object?>>();
@@ -1564,7 +1565,7 @@ public static partial class McpMod
     {
         var state = new Dictionary<string, object?>();
 
-        var inventory = merchantRoom.Inventory;
+        var inventory = merchantRoom.GetLocalInventory();
         if (inventory == null)
         {
             state["items"] = new List<Dictionary<string, object?>>();


### PR DESCRIPTION
Fixed compatibility with STS2 v0.107.1. by Codex

Changes:
- Replaced the removed `CombatManager.IsPlayPhase` property with the player-aware `IsPartOfPlayerTurn(player)` method.
- Updated target resolution to accept the new `ICombatState` interface.
- Replaced the removed `MerchantRoom.Inventory` property with `GetLocalInventory()`.
- Applied the equivalent combat-phase changes to multiplayer state and actions.
- Kept the REST API and MCP protocol unchanged; no changes were required in the Python MCP server.

Verification:
- Built against the v0.107.1 game assemblies with 0 warnings and 0 errors.
- Verified state polling at the main menu, rest site, map, and combat.
- Verified `is_play_phase` during combat.
- Successfully played a targeted card and confirmed the resulting damage and debuffs through subsequent state polling.

Not yet verified end-to-end:
- Regular shop interactions.
- Multiplayer sessions.